### PR TITLE
Resolve Warnings from compiler and clippy.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ extern crate serde;
 #[cfg(feature = "serdejson")]
 extern crate serde_json;
 #[cfg(feature = "serdejson")]
+#[cfg(test)]
 #[macro_use]
 extern crate serde_derive;
 extern crate base64;

--- a/src/nullable_format.rs
+++ b/src/nullable_format.rs
@@ -576,9 +576,9 @@ impl<T> Serialize for Nullable<T>
         where
             S: Serializer,
     {
-        match self {
-            &Nullable::Present(ref inner) => serializer.serialize_some(&inner),
-            &Nullable::Null => serializer.serialize_none(),
+        match *self {
+            Nullable::Present(ref inner) => serializer.serialize_some(&inner),
+            Nullable::Null => serializer.serialize_none(),
         }
     }
 }


### PR DESCRIPTION
When we merged the Nullable support to master, it turned out there were a few warnings.

This pull request resolves both of those.