### PR TITLE
Enable useful warnings

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -17,7 +17,9 @@ pub enum Scopes {
 /// REST API authorization.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Authorization {
+    /// Authenticated subject of the request
     pub subject: String,
+    /// Authorization scopes of the authenticated subject
     pub scopes: Scopes,
 }
 impl iron::typemap::Key for Authorization {

--- a/src/base64_format.rs
+++ b/src/base64_format.rs
@@ -10,6 +10,7 @@ use base64::{encode, decode};
 use std::ops::{Deref, DerefMut};
 
 #[derive(Debug, Clone, PartialEq, PartialOrd)]
+/// Base64-encoded byte array
 pub struct ByteArray(pub Vec<u8>);
 
 #[cfg(feature = "serdejson")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,8 @@
 //! Support crate for Swagger codegen.
 
+#![warn(missing_docs, missing_debug_implementations)]
+#![deny(unused_extern_crates)]
+
 #[cfg(feature = "serdejson")]
 extern crate serde;
 #[cfg(feature = "serdejson")]
@@ -92,7 +95,8 @@ pub struct ApiError(pub String);
 
 impl fmt::Display for ApiError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        (self as &fmt::Debug).fmt(f)
+        let debug: &fmt::Debug = self;
+        debug.fmt(f)
     }
 }
 

--- a/src/nullable_format.rs
+++ b/src/nullable_format.rs
@@ -16,7 +16,9 @@ use std::mem;
 /// Nullable implements many of the same methods as the Option type (map, unwrap, etc).
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
 pub enum Nullable<T> {
+    /// Null value
     Null,
+    /// Value is present
     Present(T),
 }
 
@@ -615,10 +617,13 @@ where
     }
 }
 
+/// Serde helper function to create a default `Option<Nullable<T>>` while
+/// deserializing
 pub fn default_optional_nullable<T>() -> Option<Nullable<T>> {
     None
 }
 
+/// Serde helper function to deserialize into an `Option<Nullable<T>>`
 #[cfg(feature = "serdejson")]
 pub fn deserialize_optional_nullable<'de, D, T>(
     deserializer: D,


### PR DESCRIPTION
Enable `missing_docs` (warning), `missing_debug_implementations` (warning) and `unused_extern_crates` (error). Enforcing this now will make for nicer code in the future.

No need for a version bump, no actual code has changed