### PR TITLE
Add static assertion macro for enforcing identical crate versions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,3 +120,50 @@ impl From<serde_json::Error> for ApiError {
         ApiError(format!("Response body did not match the schema: {}", e))
     }
 }
+
+/// Statically assert that Swagger versions used in different dependencies are
+/// the same version.
+///
+/// Until RFC 1977 (public dependencies) is accepted, the situation where
+/// multiple different versions of the same crate are present is possible. In
+/// most situations this will simply cause code to not compile, as types
+/// mismatch, however with runtime structures like `TypeMap` this leads to
+/// runtime errors (often silent!) instead. This macro allows compile-time
+/// assertion that types via different dependencies are identical, and will
+/// interoperate, which is easier to debug than runtime errors.
+///
+/// Usage:
+///
+/// ```norun
+/// use swagger;
+/// use other_crate;
+/// use another_crate;
+///
+/// assert_swagger_versions!(
+///     swagger::Context,
+///     other_crate::swagger::Context,
+///     another_crate::swagger_renamed::Context,
+/// );
+/// ```
+///
+/// Specify all versions of the same type via different dependencies. Any types
+/// that do not match the first type in the macro will cause a compile-time
+/// error.
+#[macro_export]
+macro_rules! assert_swagger_versions {
+    ( $t:ty, $( $ot:ty ),* $(,)* ) => {
+        mod swagger_assert {
+            #[allow(unused_imports)]
+            use super::*;
+
+            struct MatchingType<T>(T);
+
+            #[allow(dead_code, unreachable_patterns)]
+            fn assert_swagger_versions(mine: MatchingType<$t>) {
+                match mine {
+                    $( MatchingType::<$ot>(_) => () ),*
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
An issue exists where this crate is used by several other crates, resulting in different versions of this crate being linked into a single project. Since the types in this crate are often only used via runtime structures like `TypeMap`, this leads to silent bugs. This macro enforces that a bunch of types are identical at compile time, i.e. the versions of this crate via different dependencies all match, and so runtime structures will behave properly. Any mismatch leads to the familiar `mismatched types` error, which is easy to debug.