### PR TITLE
Add conversion of serde-xml-rs errors for xml support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,8 @@ serdexml = ["serde", "serde_derive", "serde-xml-rs"]
 serde = { version = "1.0", optional = true }
 serde_json = { version = "1.0", optional = true }
 serde_derive = { version = "1.0", optional = true }
-serde-xml-rs = { git = "ssh://git.datcon.co.uk/open-source.core/serde-xml-rs.git" , branch = "serialize", optional = true }
+#ToDo: this will be pointed at the official crate once the upstream PR to serde-xml-rs has been resolved
+serde-xml-rs = { git = "git://github.com/Metaswitch/serde-xml-rs.git" , branch = "master" , optional = true }
 hyper = "0.10"
 base64 = "0.5"
 iron = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,14 +12,17 @@ repository = "Metaswitch/swagger-rs"
 
 
 [features]
-default = ["serdejson"]
+default = ["serdejson", "serdexml"]
 
 serdejson = ["serde", "serde_json", "serde_derive"]
+
+serdexml = ["serde", "serde_derive", "serde-xml-rs"]
 
 [dependencies]
 serde = { version = "1.0", optional = true }
 serde_json = { version = "1.0", optional = true }
 serde_derive = { version = "1.0", optional = true }
+serde-xml-rs = { git = "ssh://git.datcon.co.uk/open-source.core/serde-xml-rs.git" , branch = "serialize", optional = true }
 hyper = "0.10"
 base64 = "0.5"
 iron = "0.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,12 @@
 //! Support crate for Swagger codegen.
 
-#[cfg(feature = "serdejson")]
+#[cfg(any(feature = "serdejson", feature = "serdexml"))]
 extern crate serde;
 #[cfg(feature = "serdejson")]
 extern crate serde_json;
-#[cfg(feature = "serdejson")]
+#[cfg(feature = "serdexml")]
+extern crate serde_xml_rs;
+
 #[cfg(test)]
 #[macro_use]
 extern crate serde_derive;
@@ -117,6 +119,13 @@ impl From<String> for ApiError {
 #[cfg(feature = "serdejson")]
 impl From<serde_json::Error> for ApiError {
     fn from(e: serde_json::Error) -> Self {
+        ApiError(format!("Response body did not match the schema: {}", e))
+    }
+}
+
+#[cfg(feature = "serdexml")]
+impl From<serde_xml_rs::Error> for ApiError {
+    fn from(e: serde_xml_rs::Error) -> Self {
         ApiError(format!("Response body did not match the schema: {}", e))
     }
 }


### PR DESCRIPTION
In order to add xml support to swagger codegen, we need to add support for the error types used by serde-xml-rs during serialization and deserialization. 

This PR adds a conversion trait to generate ApiErrors from serde-xml-rs::Error.

The build currently pulls from a fork of serde-xml-rs, I will re-direct it to point at the official crate once the corresponding pull request to serde-xml-rs is accepted.