### PR TITLE
Force rustfmt install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
     - rust: nightly-2017-07-25
       before_script:
       - cargo install clippy --vers 0.0.145
-      - cargo install rustfmt --vers 0.9.0
+      - cargo install rustfmt --vers 0.9.0 --force
       script:
       - cargo clippy -- -D warnings
       - cargo fmt -- --write-mode diff


### PR DESCRIPTION
At https://travis-ci.org/Metaswitch/swagger-rs/jobs/318855166, the build was failing with

```
1.38s$ cargo install rustfmt --vers 0.9.0
    Updating registry `https://github.com/rust-lang/crates.io-index`
 Downloading rustfmt v0.9.0
  Installing rustfmt v0.9.0
error: binary `cargo-fmt` already exists in destination
binary `rustfmt` already exists in destination
Add --force to overwrite


The command "cargo install rustfmt --vers 0.9.0" failed and exited with 101 during .

Your build has been stopped.
```

The only change since the previous version (which got past this point) seems to be the move from rustup 1.17.0 to rustup 1.18.0.

I'm not sure if this is the right fix, but it solves the problem (https://travis-ci.org/Metaswitch/swagger-rs/jobs/319001631).

@kw217, please can you review?