### PR TITLE
Add DropContext as inverse of AddContext

### DIFF
--- a/src/composites.rs
+++ b/src/composites.rs
@@ -86,7 +86,9 @@ where
 /// request to the first `Service` in the list for which the associated
 /// base path is a prefix of the request path.
 ///
-/// Usage:
+/// Example Usage
+/// =============
+///
 /// ```ignore
 /// let my_new_service1 = NewService1::new();
 /// let my_new_service2 = NewService2::new();

--- a/src/drop_context.rs
+++ b/src/drop_context.rs
@@ -30,7 +30,6 @@ use super::{Push, XSpanIdString};
 /// composite_new_service.push(("/base/path/2", swagger_service_two));
 /// composite_new_service.push(("/base/path/3", DropContext::new(plain_service)));
 /// ```
-
 #[derive(Debug)]
 pub struct DropContext<T, C>
 where

--- a/src/drop_context.rs
+++ b/src/drop_context.rs
@@ -7,10 +7,30 @@ use hyper;
 use hyper::{Request, Response, Error};
 use super::{Push, XSpanIdString};
 
-/// Middleware wrapper service, that can be used to include services that take a plain
-/// `hyper::Request` in a `CompositeService` wrapped in an `AddContext` service.
-/// Drops the context from the incoming request and passes the plain `hyper::Request`
-/// to the wrapped service.
+/// Middleware wrapper service that trops the context from the incoming request
+/// and passes the plain `hyper::Request` to the wrapped service.
+///
+/// This service can be used to to include services that take a plain `hyper::Request`
+/// in a `CompositeService` wrapped in an `AddContext` service.
+///
+/// Example Usage
+/// =============
+///
+/// In the following example `SwaggerService` implements `hyper::server::NewService`
+/// with `Request = (hyper::Request, SomeContext)`, and `PlainService` implements it
+/// with `Request = hyper::Request`
+///
+/// ```ignore
+/// let swagger_service_one = SwaggerService::new();
+/// let swagger_service_two = SwaggerService::new();
+/// let plain_service = PlainService::new();
+///
+/// let mut composite_new_service = CompositeNewService::new();
+/// composite_new_service.push(("/base/path/1", swagger_service_one));
+/// composite_new_service.push(("/base/path/2", swagger_service_two));
+/// composite_new_service.push(("/base/path/3", DropContext::new(plain_service)));
+/// ```
+
 #[derive(Debug)]
 pub struct DropContext<T, C>
 where

--- a/src/drop_context.rs
+++ b/src/drop_context.rs
@@ -1,0 +1,69 @@
+//! Hyper service that drops a context to an incoming request and passes it on
+//! to a wrapped service.
+
+use std::io;
+use std::marker::PhantomData;
+use hyper;
+use hyper::{Request, Response, Error};
+use super::{Push, XSpanIdString};
+
+/// Middleware wrapper service, that can be used to include services that take a plain
+/// `hyper::Request` in a `CompositeService` wrapped in an `AddContext` service.
+/// Drops the context from the incoming request and passes the plain `hyper::Request`
+/// to the wrapped service.
+#[derive(Debug)]
+pub struct DropContext<T, C>
+where
+    C: Default + Push<XSpanIdString>,
+{
+    inner: T,
+    marker: PhantomData<C>,
+}
+
+impl<T, C> DropContext<T, C>
+where
+    C: Default + Push<XSpanIdString>,
+{
+    /// Create a new DropContext struct wrapping a value
+    pub fn new(inner: T) -> Self {
+        DropContext {
+            inner,
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<T, C> hyper::server::NewService for DropContext<T, C>
+    where
+        C: Default + Push<XSpanIdString>,
+        T: hyper::server::NewService<Request=Request, Response=Response, Error=Error>,
+
+{
+    type Request = (Request, C::Result);
+    type Response = Response;
+    type Error = Error;
+    type Instance = DropContext<T::Instance, C>;
+
+    fn new_service(&self) -> Result<Self::Instance, io::Error> {
+        self.inner.new_service().map(DropContext::new)
+    }
+}
+
+impl<T, C> hyper::server::Service for DropContext<T, C>
+where
+    C: Default + Push<XSpanIdString>,
+    T: hyper::server::Service<
+        Request = Request,
+        Response = Response,
+        Error = Error,
+    >,
+{
+    type Request = (Request, C::Result);
+    type Response = Response;
+    type Error = Error;
+    type Future = T::Future;
+
+    fn call(&self, (req, _): Self::Request) -> Self::Future {
+        self.inner.call(req)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,9 @@ pub use composites::{GetPath, NotFound, CompositeNewService, CompositeService};
 pub mod add_context;
 pub use add_context::AddContext;
 
+pub mod drop_context;
+pub use drop_context::DropContext;
+
 header! {
     /// `X-Span-ID` header, used to track a request through a chain of microservices.
     (XSpanId, "X-Span-ID") => [String]


### PR DESCRIPTION
This change adds a partial inverse of AddContext that wraps a Service that expects a hyper::Request, and takes a (hyper::Request, context) pair instead.  This allows services that just request a hyper::Request to be used in a CompositeService alongside swagger generated services.