### PR TITLE
Remove unnecessary type bounds from DropContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 ### Changed
+- Fixed `DropContext` to remove trait bounds on the type of context it can drop
 
 ### Removed
 


### PR DESCRIPTION
DropContext isn't very usable because real-world Context-using Services won't match the trait bounds on C (`AddContext` isn't the only thing modifying context types).  However, the whole point is to ignore whatever the second component of the `Request` is, so `DropContext` should just be implemented over a wide-open `C`