### PR TITLE
Add SwaggerContext trait used by swagger-codegen middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
+- `SwaggerService` trait used by swagger-codegen middlewares.
 
 ### Changed
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -8,8 +8,8 @@
 
 use super::XSpanIdString;
 use auth::{AuthData, Authorization};
-use hyper;
 use futures::future::Future;
+use hyper;
 use std::marker::Sized;
 
 /// Defines methods for accessing, modifying, adding and removing the data stored

--- a/src/context.rs
+++ b/src/context.rs
@@ -9,6 +9,8 @@
 use auth::{Authorization, AuthData};
 use std::marker::Sized;
 use super::XSpanIdString;
+use hyper;
+use futures::future::Future;
 
 /// Defines methods for accessing, modifying, adding and removing the data stored
 /// in a context. Used to specify the requirements that a hyper service makes on
@@ -489,6 +491,20 @@ where
     fn with_context(self: &'a Self, context: C) -> ContextWrapper<'a, Self, C> {
         ContextWrapper::<Self, C>::new(self, context)
     }
+}
+
+/// Swagger uses a specific specialization of the hyper Service trait.
+pub trait SwaggerService<C>
+    : Clone
+    + hyper::server::Service<
+    Request = (hyper::server::Request, C),
+    Response = hyper::server::Response,
+    Error = hyper::Error,
+    Future = Box<Future<Item = hyper::server::Response, Error = hyper::Error>>,
+>
+where
+    C: Clone + 'static,
+{
 }
 
 #[cfg(test)]

--- a/src/context.rs
+++ b/src/context.rs
@@ -503,7 +503,7 @@ pub trait SwaggerService<C>
     Future = Box<Future<Item = hyper::server::Response, Error = hyper::Error>>,
 >
 where
-    C: Clone + 'static
+    C: Has<Option<AuthData>> + Has<Option<Authorization>> + Has<XSpanIdString> + Clone + 'static
 {
 }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -505,6 +505,8 @@ where
 ///           Has<XSpanIdString> +
 ///           Clone +
 ///           'static,
+/// {
+/// }
 /// ```
 pub trait SwaggerService<C>:
     Clone

--- a/src/context.rs
+++ b/src/context.rs
@@ -503,7 +503,7 @@ where
 /// # use std::marker::PhantomData;
 /// # use swagger::auth::{AuthData, Authorization};
 /// # use swagger::XSpanIdString;
-/// 
+///
 /// struct ExampleMiddleware<T, C> {
 ///     inner: T,
 ///     marker: PhantomData<C>,

--- a/src/context.rs
+++ b/src/context.rs
@@ -7,9 +7,9 @@
 //! See the `context_tests` module below for examples of how to use.
 
 use super::XSpanIdString;
+use auth::{AuthData, Authorization};
 use hyper;
 use futures::future::Future;
-use auth::{AuthData, Authorization};
 use std::marker::Sized;
 
 /// Defines methods for accessing, modifying, adding and removing the data stored
@@ -495,16 +495,16 @@ where
 }
 
 /// Swagger uses a specific specialization of the hyper Service trait.
-pub trait SwaggerService<C>
-    : Clone
+pub trait SwaggerService<C>:
+    Clone
     + hyper::server::Service<
-    Request = (hyper::server::Request, C),
-    Response = hyper::server::Response,
-    Error = hyper::Error,
-    Future = Box<Future<Item = hyper::server::Response, Error = hyper::Error>>,
->
+        Request = (hyper::server::Request, C),
+        Response = hyper::server::Response,
+        Error = hyper::Error,
+        Future = Box<Future<Item = hyper::server::Response, Error = hyper::Error>>,
+    >
 where
-    C: Has<Option<AuthData>> + Has<Option<Authorization>> + Has<XSpanIdString> + Clone + 'static
+    C: Has<Option<AuthData>> + Has<Option<Authorization>> + Has<XSpanIdString> + Clone + 'static,
 {
 }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -508,7 +508,7 @@ where
 {
 }
 
-impl <T, C> SwaggerService<C> for T
+impl<T, C> SwaggerService<C> for T
 where
     T: Clone
         + hyper::server::Service<

--- a/src/context.rs
+++ b/src/context.rs
@@ -494,7 +494,18 @@ where
     }
 }
 
-/// Swagger uses a specific specialization of the hyper Service trait.
+/// Trait designed to ensure consistency in context used by swagger middlewares
+///
+/// ```rust
+/// impl<T, C> hyper::server::Service for ExampleMiddleware<T, C>
+///    where
+///        T: SwaggerService<C>,
+///        C: Has<Option<AuthData>> +
+///           Has<Option<Authorization>> +
+///           Has<XSpanIdString> +
+///           Clone +
+///           'static,
+/// ```
 pub trait SwaggerService<C>:
     Clone
     + hyper::server::Service<

--- a/src/context.rs
+++ b/src/context.rs
@@ -497,14 +497,24 @@ where
 /// Trait designed to ensure consistency in context used by swagger middlewares
 ///
 /// ```rust
+/// # extern crate hyper;
+/// # extern crate swagger;
+/// # use swagger::context::*;
+/// # use std::marker::PhantomData;
+/// 
+/// struct ExampleMiddleware<T, C> {
+///     inner: T,
+///     marker: PhantomData<C>,
+/// }
+///
 /// impl<T, C> hyper::server::Service for ExampleMiddleware<T, C>
-///    where
-///        T: SwaggerService<C>,
-///        C: Has<Option<AuthData>> +
-///           Has<Option<Authorization>> +
-///           Has<XSpanIdString> +
-///           Clone +
-///           'static,
+///     where
+///         T: SwaggerService<C>,
+///         C: Has<Option<AuthData>> +
+///            Has<Option<Authorization>> +
+///            Has<XSpanIdString> +
+///            Clone +
+///            'static,
 /// {
 /// }
 /// ```

--- a/src/context.rs
+++ b/src/context.rs
@@ -501,6 +501,8 @@ where
 /// # extern crate swagger;
 /// # use swagger::context::*;
 /// # use std::marker::PhantomData;
+/// # use swagger::auth::{AuthData, Authorization};
+/// # use swagger::XSpanIdString;
 /// 
 /// struct ExampleMiddleware<T, C> {
 ///     inner: T,
@@ -516,6 +518,13 @@ where
 ///            Clone +
 ///            'static,
 /// {
+///     type Request = (hyper::Request, C);
+///     type Response = T::Response;
+///     type Error = T::Error;
+///     type Future = T::Future;
+///     fn call(&self, (req, context) : Self::Request) -> Self::Future {
+///         self.inner.call((req, context))
+///     }    
 /// }
 /// ```
 pub trait SwaggerService<C>:

--- a/src/context.rs
+++ b/src/context.rs
@@ -503,7 +503,7 @@ pub trait SwaggerService<C>
     Future = Box<Future<Item = hyper::server::Response, Error = hyper::Error>>,
 >
 where
-    C: Clone + 'static,
+    C: Clone + 'static
 {
 }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -508,6 +508,19 @@ where
 {
 }
 
+impl <T, C> SwaggerService<C> for T
+where
+    T: Clone
+        + hyper::server::Service<
+            Request = (hyper::server::Request, C),
+            Response = hyper::server::Response,
+            Error = hyper::Error,
+            Future = Box<Future<Item = hyper::server::Response, Error = hyper::Error>>,
+        >,
+    C: Has<Option<AuthData>> + Has<Option<Authorization>> + Has<XSpanIdString> + Clone + 'static,
+{
+}
+
 #[cfg(test)]
 mod context_tests {
     use super::*;


### PR DESCRIPTION
This change adds the SwaggerService trait to swagger-rs, this trait is used by swagger middlewares.