### PR TITLE
Use clippy-preview from 2018-07-16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,9 @@ matrix:
   allow_failures:
     - rust: nightly
   include:
-    - rust: nightly-2018-05-30
+    - rust: nightly-2018-07-16
       before_script:
-      - cargo install clippy --vers 0.0.206
+      - rustup component add clippy-preview
       script:
       - cargo clippy -- -D warnings
     - rust: stable


### PR DESCRIPTION
I'm not sure why, but the old way of getting clippy (cargo install) now seems to be broken on travis.