### PR TITLE
Update clippy/rustfmt version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
   allow_failures:
     - rust: nightly
   include:
-    - rust: nightly-2018-07-16
+    - rust: nightly-2018-09-12
       before_script:
       - rustup component add clippy-preview
       script:

--- a/src/composites.rs
+++ b/src/composites.rs
@@ -94,8 +94,15 @@ where
     V: NotFound + 'static,
     W: 'static;
 
-// Clippy bug? This lint triggers despite having a #[derive(Default)]
-#[cfg_attr(feature = "cargo-clippy", allow(new_without_default_derive))]
+// Workaround for https://github.com/rust-lang-nursery/rust-clippy/issues/2226
+#[cfg_attr(
+    feature = "cargo-clippy",
+    allow(
+        renamed_and_removed_lints,
+        new_without_default_derive,
+        clippy::new_without_default_derive
+    )
+)]
 impl<U: GetPath, V: NotFound, W> CompositeNewService<U, V, W> {
     /// create an empty `CompositeNewService`
     pub fn new() -> Self {

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -1,8 +1,24 @@
 //! Utility methods for instantiating common connectors for clients.
 extern crate hyper_tls;
-#[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "ios")))]
+#[cfg(
+    not(
+        any(
+            target_os = "macos",
+            target_os = "windows",
+            target_os = "ios"
+        )
+    )
+)]
 extern crate native_tls;
-#[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "ios")))]
+#[cfg(
+    not(
+        any(
+            target_os = "macos",
+            target_os = "windows",
+            target_os = "ios"
+        )
+    )
+)]
 extern crate openssl;
 extern crate tokio_core;
 
@@ -22,7 +38,15 @@ pub fn http_connector() -> Box<Fn(&Handle) -> hyper::client::HttpConnector + Sen
 /// # Arguments
 ///
 /// * `ca_certificate` - Path to CA certificate used to authenticate the server
-#[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "ios")))]
+#[cfg(
+    not(
+        any(
+            target_os = "macos",
+            target_os = "windows",
+            target_os = "ios"
+        )
+    )
+)]
 pub fn https_connector<CA>(
     ca_certificate: CA,
 ) -> Box<Fn(&Handle) -> hyper_tls::HttpsConnector<hyper::client::HttpConnector> + Send + Sync>
@@ -50,7 +74,13 @@ where
 
 /// Not currently implemented on Mac OS X, iOS and Windows.
 /// This function will panic when called.
-#[cfg(any(target_os = "macos", target_os = "windows", target_os = "ios"))]
+#[cfg(
+    any(
+        target_os = "macos",
+        target_os = "windows",
+        target_os = "ios"
+    )
+)]
 pub fn https_connector<CA>(
     _ca_certificate: CA,
 ) -> Box<Fn(&Handle) -> hyper_tls::HttpsConnector<hyper::client::HttpConnector> + Send + Sync>
@@ -66,7 +96,15 @@ where
 /// * `ca_certificate` - Path to CA certificate used to authenticate the server
 /// * `client_key` - Path to the client private key
 /// * `client_certificate` - Path to the client's public certificate associated with the private key
-#[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "ios")))]
+#[cfg(
+    not(
+        any(
+            target_os = "macos",
+            target_os = "windows",
+            target_os = "ios"
+        )
+    )
+)]
 pub fn https_mutual_connector<CA, K, C>(
     ca_certificate: CA,
     client_key: K,
@@ -107,7 +145,13 @@ where
 
 /// Not currently implemented on Mac OS X, iOS and Windows.
 /// This function will panic when called.
-#[cfg(any(target_os = "macos", target_os = "windows", target_os = "ios"))]
+#[cfg(
+    any(
+        target_os = "macos",
+        target_os = "windows",
+        target_os = "ios"
+    )
+)]
 pub fn https_mutual_connector<CA, K, C>(
     _ca_certificate: CA,
     _client_key: K,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! Support crate for Swagger codegen.
-
 #![warn(missing_docs, missing_debug_implementations)]
 #![deny(unused_extern_crates)]
+#![cfg_attr(feature = "cargo-clippy", feature(tool_lints))]
 
 #[cfg(feature = "serdejson")]
 extern crate serde;


### PR DESCRIPTION
Update the versions of clippy and rustfmt we use. The build is currently broken because one of our dependencies no longer compiles under the version of nightly rust we used for clippy.