### PR TITLE
Fix clippy unused doc comment lint

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -381,7 +381,7 @@ macro_rules! new_context_type {
     };
 }
 
-/// Create a default context type to export.
+// Create a default context type to export.
 new_context_type!(
     ContextBuilder,
     EmptyContext,


### PR DESCRIPTION
This fixes:

```
    Checking swagger v2.0.2 (/home/travis/build/Metaswitch/swagger-rs)
error: unused doc comment
   --> src/context.rs:384:1
    |
384 |   /// Create a default context type to export.
    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
385 | / new_context_type!(
386 | |     ContextBuilder,
387 | |     EmptyContext,
388 | |     XSpanIdString,
389 | |     Option<AuthData>,
390 | |     Option<Authorization>
391 | | );
    | |__- rustdoc does not generate documentation for macro expansions
    |
    = note: `-D unused-doc-comments` implied by `-D warnings`
    = help: to document an item produced by a macro, the macro must produce the documentation as part of its expansion
```

seen in both master, and v2.