### PR TITLE
[WIP] Update to Hyper 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,8 @@ base64 = "0.10"
 mime = { version = "0.3", optional = true }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
-hyper = "0.13.0-alpha.4"
+#hyper = "0.13.0-alpha.4"
+hyper = { git = "https://github.com/hyperium/hyper.git", branch = "master" }
 hyper-tls = "0.4.0-alpha.4"
 hyper-old-types = "0.11.0"
 native-tls = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://github.com/Metaswitch/swagger-rs"
 repository = "https://github.com/Metaswitch/swagger-rs"
 readme = "README.md"
 keywords = ["swagger"]
+edition = "2018"
 
 [badges.travis-ci]
 repository = "Metaswitch/swagger-rs"
@@ -15,21 +16,21 @@ repository = "Metaswitch/swagger-rs"
 [features]
 default = ["serdejson"]
 multipart = ["mime"]
-serdejson = ["serde", "serde_json", "serde_derive"]
+serdejson = ["serde", "serde_json"]
 
 [dependencies]
+async-trait = "0.1"
 base64 = "0.10"
 mime = { version = "0.3", optional = true }
-serde = { version = "1.0", optional = true }
+serde = { version = "1.0", optional = true, features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
-serde_derive = { version = "1.0", optional = true }
-hyper = "0.12.25"
-hyper-tls = "0.2.1"
-native-tls = "0.1.4"
-openssl = "0.9.14"
-slog = { version = "2", features = [ "max_level_trace", "release_max_level_debug"] }
-futures = "0.1"
-uuid = {version = "0.7", features = ["serde", "v4"]}
+hyper = "0.13.0-alpha.4"
+hyper-tls = "0.4.0-alpha.4"
 hyper-old-types = "0.11.0"
+native-tls = "0.2"
+openssl = "0.10"
+slog = { version = "2", features = [ "max_level_trace", "release_max_level_debug"] }
+futures-preview = "0.3.0-alpha.19"
+uuid = {version = "0.7", features = ["serde", "v4"]}
 chrono = "0.4.6"
 

--- a/src/add_context.rs
+++ b/src/add_context.rs
@@ -1,14 +1,15 @@
 //! Hyper service that adds a context to an incoming request and passes it on
 //! to a wrapped service.
 
-use super::{Push, XSpanIdString};
-use context::ContextualPayload;
-use futures::Future;
+use crate::{ErrorBound, Push, XSpanIdString};
+use crate::context::ContextualPayload;
+use futures::FutureExt;
 use hyper;
 use hyper::Request;
+use std::future::Future;
 use std::marker::PhantomData;
-
-use ErrorBound;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 
 /// Middleware wrapper service, that should be used as the outermost layer in a
 /// stack of hyper services. Adds a context to a plain `hyper::Request` that can be
@@ -37,43 +38,38 @@ where
     }
 }
 
-impl<'a, T, SC, RC, E, ME, S, F> hyper::service::MakeService<&'a SC>
+impl<'a, T, SC, RC, E, ME, S> hyper::service::Service<&'a SC>
     for AddContextMakeService<T, RC>
 where
     RC: Default + Push<XSpanIdString> + 'static + Send,
     RC::Result: Send + 'static,
-    T: hyper::service::MakeService<
+    T: hyper::service::Service<
         &'a SC,
-        Service = S,
-        ReqBody = ContextualPayload<hyper::Body, RC::Result>,
-        ResBody = hyper::Body,
-        Error = E,
-        MakeError = ME,
-        Future = F,
+        ResBody = S,
+        Error = ME,
+        Future = Pin<Box<dyn Future<Output=Result<S, ME>>>>,
     >,
     S: hyper::service::Service<
-            ReqBody = ContextualPayload<hyper::Body, RC::Result>,
+            ContextualPayload<hyper::Body, RC::Result>,
             ResBody = hyper::Body,
             Error = E,
         > + 'static,
     ME: ErrorBound,
     E: ErrorBound,
-    F: Future<Item = S, Error = ME> + Send + 'static,
     S::Future: Send,
 {
-    type ReqBody = hyper::Body;
-    type ResBody = hyper::Body;
-    type Error = E;
-    type Service = AddContextService<S, RC>;
-    type MakeError = ME;
-    type Future = Box<dyn Future<Item = Self::Service, Error = ME> + Send>;
+    type ResBody = T;
+    type Error = ME;
+    type Future = Pin<Box<dyn Future<Output = Result<AddContextService<S, RC>, Self::Error>> + Send>>;
 
-    fn make_service(&mut self, service_ctx: &'a SC) -> Self::Future {
-        Box::new(
-            self.inner
-                .make_service(service_ctx)
-                .map(AddContextService::new),
-        )
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, service_ctx: &'a SC) -> Self::Future {
+        self.inner
+            .call(service_ctx)
+            .map(AddContextService::new)
     }
 }
 
@@ -106,23 +102,26 @@ where
     }
 }
 
-impl<T, C, E> hyper::service::Service for AddContextService<T, C>
+impl<T, C, E> hyper::service::Service<ContextualPayload<hyper::Body, C::Result>> for AddContextService<T, C>
 where
     C: Default + Push<XSpanIdString>,
     C::Result: Send + 'static,
     T: hyper::service::Service<
-        ReqBody = ContextualPayload<hyper::Body, C::Result>,
+        ContextualPayload<hyper::Body, C::Result>,
         ResBody = hyper::Body,
         Error = E,
     >,
     E: ErrorBound,
 {
-    type ReqBody = hyper::Body;
     type ResBody = hyper::Body;
     type Error = E;
     type Future = T::Future;
 
-    fn call(&mut self, req: Request<Self::ReqBody>) -> Self::Future {
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: Request<ContextualPayload<hyper::Body, C::Result>>) -> Self::Future {
         let x_span_id = XSpanIdString::get_or_generate(&req);
         let (head, body) = req.into_parts();
         let context = C::default().push(x_span_id);

--- a/src/base64_format.rs
+++ b/src/base64_format.rs
@@ -29,7 +29,7 @@ impl<'de> Deserialize<'de> for ByteArray {
     where
         D: Deserializer<'de>,
     {
-        let s = try!(String::deserialize(deserializer));
+        let s = String::deserialize(deserializer)?;
         match decode(&s) {
             Ok(bin) => Ok(ByteArray(bin)),
             _ => Err(D::Error::custom("invalid base64")),

--- a/src/client.rs
+++ b/src/client.rs
@@ -19,9 +19,12 @@ impl<C, B> Service<HyperResult> for hyper::Client<C, B>
 where
     B: hyper::body::Payload + Unpin + Send + 'static,
     B::Data: Send + Unpin,
-    C: hyper::client::connect::Connect + Sync + 'static,
-    C::Transport: 'static,
-    C::Future: 'static,
+    C: hyper::service::Service<hyper::client::connect::Destination, Response=(B, hyper::client::connect::Connected)>
+        + Clone + Send + Sync,
+    C::Future: Unpin,
+//    C: Service<B> + Sync + 'static,
+//    C::Transport: 'static,
+//    C::Future: 'static,
 {
     type ReqBody = B;
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,44 +1,44 @@
+use async_trait::async_trait;
+use crate::ContextualPayload;
+
+pub type HyperResult = Result<hyper::Response<hyper::Body>, hyper::Error>;
+
 /// Common trait for swagger based client middleware
-pub trait Service {
+#[async_trait]
+pub trait Service<T> {
     /// Request body taken by client.
     /// Likely either `hyper::Body`, `hyper::Chunk` or `swagger::ContextualPayload`.
     type ReqBody: hyper::body::Payload;
 
-    /// Future response from client service.
-    /// Likely: `Future<Item=hyper::Response<hyper::Body>, Error=hyper::Error>`
-    type Future: futures::Future;
-
     /// Handle the given request
-    fn request(&self, req: hyper::Request<Self::ReqBody>) -> Self::Future;
+    async fn request(&self, req: hyper::Request<Self::ReqBody>) -> T;
 }
 
-impl<C, B> Service for hyper::Client<C, B>
+#[async_trait]
+impl<C, B> Service<HyperResult> for hyper::Client<C, B>
 where
-    B: hyper::body::Payload + Send + 'static,
-    B::Data: Send,
+    B: hyper::body::Payload + Unpin + Send + 'static,
+    B::Data: Send + Unpin,
     C: hyper::client::connect::Connect + Sync + 'static,
     C::Transport: 'static,
     C::Future: 'static,
 {
     type ReqBody = B;
-    type Future = hyper::client::ResponseFuture;
 
-    fn request(&self, req: hyper::Request<Self::ReqBody>) -> Self::Future {
-        hyper::Client::request(self, req)
+    async fn request(&self, req: hyper::Request<Self::ReqBody>) -> HyperResult {
+        hyper::Client::request(self, req).await
     }
 }
 
 /// Factory trait for creating Services - swagger based client middleware
+#[async_trait]
 pub trait MakeService<Context> {
     /// Service that this creates
-    type Service: Service;
+    type Service: Service<ContextualPayload<hyper::Body, Context>>;
 
     /// Potential error from creating the service.
     type Error;
 
-    /// Future response creating the service.
-    type Future: futures::Future<Item = Self::Service, Error = Self::Error>;
-
     /// Handle the given request
-    fn make_service(&self, ctx: Context) -> Self::Future;
+    async fn make_service(&self, ctx: Context) -> Result<Self::Service, Self::Error>;
 }

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -12,7 +12,7 @@ use hyper;
 /// Returns a function which creates an http-connector. Used for instantiating
 /// clients with custom connectors
 pub fn http_connector() -> Box<dyn Fn() -> hyper::client::HttpConnector + Send + Sync> {
-    Box::new(move || hyper::client::HttpConnector::new(4))
+    Box::new(move || hyper::client::HttpConnector::new())
 }
 
 /// Returns a function which creates an https-connector

--- a/src/drop_context.rs
+++ b/src/drop_context.rs
@@ -61,16 +61,16 @@ where
     RC: Send + 'static,
     T: hyper::service::Service<
         &'a SC,
-        ResBody = S,
+        Response = S,
         Error = io::Error,
         Future = F,
     >,
     T::Future: 'static,
-    S: hyper::service::Service<hyper::Body, ResBody = hyper::Body, Error = Error>
+    S: hyper::service::Service<hyper::Body, Response = hyper::Body, Error = Error>
         + 'static,
     F: Future<Output = Result<S, io::Error>>,
 {
-    type ResBody = DropContextService<T, RC>;
+    type Response = DropContextService<T, RC>;
     type Error = Error;
     type Future = Pin<Box<dyn Future<Output = Result<S, io::Error>>>>;
 
@@ -93,7 +93,7 @@ where
 pub struct DropContextService<T, C>
 where
     C: Send + 'static,
-    T: hyper::service::Service<hyper::Body, ResBody = hyper::Body, Error = Error>,
+    T: hyper::service::Service<hyper::Body, Response = hyper::Body, Error = Error>,
 {
     inner: T,
     marker: PhantomData<C>,
@@ -102,7 +102,7 @@ where
 impl<T, C> DropContextService<T, C>
 where
     C: Send + 'static,
-    T: hyper::service::Service<hyper::Body, ResBody = hyper::Body, Error = Error>,
+    T: hyper::service::Service<hyper::Body, Response = hyper::Body, Error = Error>,
 {
     /// Create a new DropContextService struct wrapping a value
     pub fn new(inner: T) -> Self {
@@ -115,9 +115,9 @@ where
 impl<T, C> hyper::service::Service<hyper::Body> for DropContextService<T, C>
 where
     C: Send + 'static,
-    T: hyper::service::Service<hyper::Body, ResBody = hyper::Body, Error = Error>,
+    T: hyper::service::Service<hyper::Body, Response = hyper::Body, Error = Error>,
 {
-    type ResBody = hyper::Body;
+    type Response = hyper::Body;
     type Error = Error;
     type Future = T::Future;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,24 +2,6 @@
 #![warn(missing_docs, missing_debug_implementations)]
 #![deny(unused_extern_crates)]
 
-#[cfg(feature = "serdejson")]
-extern crate serde;
-#[cfg(feature = "serdejson")]
-extern crate serde_json;
-#[cfg(feature = "serdejson")]
-#[cfg(test)]
-#[macro_use]
-extern crate serde_derive;
-
-extern crate base64;
-extern crate chrono;
-extern crate futures;
-extern crate hyper;
-extern crate hyper_old_types;
-#[cfg(feature = "multipart")]
-extern crate mime;
-extern crate uuid;
-
 use std::error;
 use std::fmt;
 

--- a/src/nullable_format.rs
+++ b/src/nullable_format.rs
@@ -640,6 +640,7 @@ where
 #[cfg(feature = "serdejson")]
 mod serde_tests {
     use super::*;
+    use serde::{Deserialize, Serialize};
 
     // Set up:
     #[derive(Clone, Debug, Deserialize, Serialize)]


### PR DESCRIPTION
Update to hyper 0.13 and std::future::Future.

Meant for https://github.com/OpenAPITools/openapi-generator/pull/4210

Currently blocked on another release of hyper, where it is easier to tower services, and make service is no longer needed.

Existing release of hyper runs into multiple implementation issues due to blanket implementations for tower::Service.