### PR TITLE
Handle Hyper 0.11's Headers implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
+- Add `SafeHeaders` to work around Hyper 0.11 panic handling differently type headers with the same name - e.g. Authorization
+- Fix warnings present on Rust 1.39
 
 ### Changed
 

--- a/src/base64_format.rs
+++ b/src/base64_format.rs
@@ -29,7 +29,7 @@ impl<'de> Deserialize<'de> for ByteArray {
     where
         D: Deserializer<'de>,
     {
-        let s = try!(String::deserialize(deserializer));
+        let s = String::deserialize(deserializer)?;
         match decode(&s) {
             Ok(bin) => Ok(ByteArray(bin)),
             _ => Err(D::Error::custom("invalid base64")),

--- a/src/composites.rs
+++ b/src/composites.rs
@@ -41,10 +41,10 @@ impl NotFound for Response {
     }
 }
 
-type BoxedFuture<V, W> = Box<Future<Item = V, Error = W>>;
-type CompositeNewServiceVec<U, V, W> = Vec<(&'static str, Box<BoxedNewService<U, V, W>>)>;
+type BoxedFuture<V, W> = Box<dyn Future<Item = V, Error = W>>;
+type CompositeNewServiceVec<U, V, W> = Vec<(&'static str, Box<dyn BoxedNewService<U, V, W>>)>;
 type BoxedService<U, V, W> =
-    Box<Service<Request = U, Response = V, Error = W, Future = BoxedFuture<V, W>>>;
+    Box<dyn Service<Request = U, Response = V, Error = W, Future = BoxedFuture<V, W>>>;
 
 /// Trait for wrapping hyper `NewService`s to make the return type of `new_service` uniform.
 /// This is necessary in order for the `NewService`s with different `Instance` types to
@@ -185,7 +185,7 @@ where
     type Request = U;
     type Response = V;
     type Error = W;
-    type Future = Box<Future<Item = V, Error = W>>;
+    type Future = Box<dyn Future<Item = V, Error = W>>;
 
     fn call(&self, req: Self::Request) -> Self::Future {
         let mut result = None;

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -13,7 +13,7 @@ use hyper;
 
 /// Returns a function which creates an http-connector. Used for instantiating
 /// clients with custom connectors
-pub fn http_connector() -> Box<Fn(&Handle) -> hyper::client::HttpConnector + Send + Sync> {
+pub fn http_connector() -> Box<dyn Fn(&Handle) -> hyper::client::HttpConnector + Send + Sync> {
     Box::new(move |handle: &Handle| hyper::client::HttpConnector::new(4, handle))
 }
 
@@ -25,7 +25,7 @@ pub fn http_connector() -> Box<Fn(&Handle) -> hyper::client::HttpConnector + Sen
 #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "ios")))]
 pub fn https_connector<CA>(
     ca_certificate: CA,
-) -> Box<Fn(&Handle) -> hyper_tls::HttpsConnector<hyper::client::HttpConnector> + Send + Sync>
+) -> Box<dyn Fn(&Handle) -> hyper_tls::HttpsConnector<hyper::client::HttpConnector> + Send + Sync>
 where
     CA: AsRef<Path>,
 {
@@ -53,7 +53,7 @@ where
 #[cfg(any(target_os = "macos", target_os = "windows", target_os = "ios"))]
 pub fn https_connector<CA>(
     _ca_certificate: CA,
-) -> Box<Fn(&Handle) -> hyper_tls::HttpsConnector<hyper::client::HttpConnector> + Send + Sync>
+) -> Box<dyn Fn(&Handle) -> hyper_tls::HttpsConnector<hyper::client::HttpConnector> + Send + Sync>
 where
     CA: AsRef<Path>,
 {
@@ -71,7 +71,7 @@ pub fn https_mutual_connector<CA, K, C>(
     ca_certificate: CA,
     client_key: K,
     client_certificate: C,
-) -> Box<Fn(&Handle) -> hyper_tls::HttpsConnector<hyper::client::HttpConnector> + Send + Sync>
+) -> Box<dyn Fn(&Handle) -> hyper_tls::HttpsConnector<hyper::client::HttpConnector> + Send + Sync>
 where
     CA: AsRef<Path>,
     K: AsRef<Path>,
@@ -112,7 +112,7 @@ pub fn https_mutual_connector<CA, K, C>(
     _ca_certificate: CA,
     _client_key: K,
     _client_certificate: C,
-) -> Box<Fn(&Handle) -> hyper_tls::HttpsConnector<hyper::client::HttpConnector> + Send + Sync>
+) -> Box<dyn Fn(&Handle) -> hyper_tls::HttpsConnector<hyper::client::HttpConnector> + Send + Sync>
 where
     CA: AsRef<Path>,
     K: AsRef<Path>,

--- a/src/context.rs
+++ b/src/context.rs
@@ -38,7 +38,7 @@ use std::marker::Sized;
 ///     type Request = (hyper::Request, C);
 ///     type Response = hyper::Response;
 ///     type Error = hyper::Error;
-///     type Future = Box<Future<Item=Self::Response, Error=Self::Error>>;
+///     type Future = Box<dyn Future<Item=Self::Response, Error=Self::Error>>;
 ///     fn call(&self, (req, context) : Self::Request) -> Self::Future {
 ///         do_something_with_my_item(Has::<MyItem>::get(&context));
 ///         Box::new(ok(hyper::Response::new()))
@@ -546,7 +546,7 @@ pub trait SwaggerService<C>:
         Request = (hyper::server::Request, C),
         Response = hyper::server::Response,
         Error = hyper::Error,
-        Future = Box<Future<Item = hyper::server::Response, Error = hyper::Error>>,
+        Future = Box<dyn Future<Item = hyper::server::Response, Error = hyper::Error>>,
     >
 where
     C: Has<Option<AuthData>> + Has<Option<Authorization>> + Has<XSpanIdString> + Clone + 'static,
@@ -560,7 +560,7 @@ where
             Request = (hyper::server::Request, C),
             Response = hyper::server::Response,
             Error = hyper::Error,
-            Future = Box<Future<Item = hyper::server::Response, Error = hyper::Error>>,
+            Future = Box<dyn Future<Item = hyper::server::Response, Error = hyper::Error>>,
         >,
     C: Has<Option<AuthData>> + Has<Option<Authorization>> + Has<XSpanIdString> + Clone + 'static,
 {
@@ -603,7 +603,7 @@ mod context_tests {
         type Request = (Request, C);
         type Response = Response;
         type Error = Error;
-        type Future = Box<Future<Item = Response, Error = Error>>;
+        type Future = Box<dyn Future<Item = Response, Error = Error>>;
         fn call(&self, (_, context): Self::Request) -> Self::Future {
             use_item_2(Has::<ContextItem2>::get(&context));
 

--- a/src/headers.rs
+++ b/src/headers.rs
@@ -24,7 +24,7 @@ impl SafeHeaders for Headers {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use hyper::header::{Authorization, Bearer, Basic};
+    use hyper::header::{Authorization, Basic, Bearer};
 
     #[test]
     fn test() {

--- a/src/headers.rs
+++ b/src/headers.rs
@@ -1,0 +1,39 @@
+//! Support library for handling headers in a safe manner
+
+use hyper::header::{Header, Headers};
+
+/// Trait to add a mechanism to safely retrieve a header.
+///
+/// In Hyper 0.11, if you add an Authorization<Basic> header,
+/// and then attempt get an Authorization<Bearer> header, the code
+/// will panic, as the type ID doesn't match.
+pub trait SafeHeaders {
+    /// Safely get a header from a hyper::header::Headers
+    fn safe_get<H: Header>(&self) -> Option<H>;
+}
+
+impl SafeHeaders for Headers {
+    fn safe_get<H: Header>(&self) -> Option<H> {
+        self.get_raw(H::header_name())
+            .map(H::parse_header)
+            .map(Result::ok)
+            .unwrap_or(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hyper::header::{Authorization, Bearer, Basic};
+
+    #[test]
+    fn test() {
+        let mut headers = Headers::default();
+        let basic = Basic {
+            username: "richard".to_string(),
+            password: None,
+        };
+        headers.set::<Authorization<Basic>>(Authorization(basic));
+        println!("Auth: {:?}", headers.safe_get::<Authorization<Bearer>>());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,8 @@ pub use drop_context::DropContext;
 pub mod request_parser;
 pub use request_parser::RequestParser;
 
+pub mod headers;
+
 header! {
     /// `X-Span-ID` header, used to track a request through a chain of microservices.
     (XSpanId, "X-Span-ID") => [String]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@ pub struct ApiError(pub String);
 
 impl fmt::Display for ApiError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let debug: &fmt::Debug = self;
+        let debug: &dyn fmt::Debug = self;
         debug.fmt(f)
     }
 }


### PR DESCRIPTION
In Hyper 0.11, the following code will panic:

    use hyper::header::{Authorization, Basic, Bearer, Headers};
    fn main() {
        let mut headers = Headers::default();
        let basic = Basic { username: "richard".to_string(), password: None };
        headers.set::<Authorization<Basic>>(Authorization(basic));
        println!("Auth: {:?}", headers.get::<Authorization<Bearer>>());
    }

This is because `std::any::TypeId::of<Authorization<Basic>>` and
`std::any::TypeId::of<Authorization<Bearer>>` don't match, but the header
name, `Authorization` does.

We provide a `.safe_get::<Authorization<Bearer>>` to workaround this issue.