### PR TITLE
Update swagger-rs to Rust 2018 Edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://github.com/Metaswitch/swagger-rs"
 repository = "https://github.com/Metaswitch/swagger-rs"
 readme = "README.md"
 keywords = ["swagger"]
+edition = "2018"
 
 [badges.travis-ci]
 repository = "Metaswitch/swagger-rs"
@@ -15,14 +16,13 @@ repository = "Metaswitch/swagger-rs"
 [features]
 default = ["serdejson"]
 multipart = ["mime"]
-serdejson = ["serde", "serde_json", "serde_derive"]
+serdejson = ["serde", "serde_json"]
 
 [dependencies]
 base64 = "0.10"
 mime = { version = "0.3", optional = true }
-serde = { version = "1.0", optional = true }
+serde = { version = "1.0", optional = true, features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
-serde_derive = { version = "1.0", optional = true }
 hyper = "0.12.25"
 hyper-tls = "0.2.1"
 native-tls = "0.1.4"

--- a/src/add_context.rs
+++ b/src/add_context.rs
@@ -1,14 +1,12 @@
 //! Hyper service that adds a context to an incoming request and passes it on
 //! to a wrapped service.
 
-use super::{Push, XSpanIdString};
-use context::ContextualPayload;
+use crate::{ErrorBound, Push, XSpanIdString};
+use crate::context::ContextualPayload;
 use futures::Future;
 use hyper;
 use hyper::Request;
 use std::marker::PhantomData;
-
-use ErrorBound;
 
 /// Middleware wrapper service, that should be used as the outermost layer in a
 /// stack of hyper services. Adds a context to a plain `hyper::Request` that can be

--- a/src/add_context.rs
+++ b/src/add_context.rs
@@ -1,8 +1,8 @@
 //! Hyper service that adds a context to an incoming request and passes it on
 //! to a wrapped service.
 
-use crate::{ErrorBound, Push, XSpanIdString};
 use crate::context::ContextualPayload;
+use crate::{ErrorBound, Push, XSpanIdString};
 use futures::Future;
 use hyper;
 use hyper::Request;

--- a/src/base64_format.rs
+++ b/src/base64_format.rs
@@ -1,6 +1,5 @@
 // These functions are only used if the API uses base64-encoded properties, so allow them to be
 // dead code.
-#![allow(dead_code)]
 #[cfg(feature = "serdejson")]
 use base64::{decode, encode};
 #[cfg(feature = "serdejson")]
@@ -29,7 +28,7 @@ impl<'de> Deserialize<'de> for ByteArray {
     where
         D: Deserializer<'de>,
     {
-        let s = try!(String::deserialize(deserializer));
+        let s = String::deserialize(deserializer)?;
         match decode(&s) {
             Ok(bin) => Ok(ByteArray(bin)),
             _ => Err(D::Error::custom("invalid base64")),

--- a/src/composites.rs
+++ b/src/composites.rs
@@ -137,7 +137,7 @@ where
     V: NotFound<V> + 'static,
     W: 'static,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         // Get vector of base paths
         let str_vec: Vec<&'static str> = self.0.iter().map(|&(base_path, _)| base_path).collect();
         write!(
@@ -206,7 +206,7 @@ where
     V: NotFound<V> + 'static,
     W: 'static,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         // Get vector of base paths
         let str_vec: Vec<&'static str> = self.0.iter().map(|&(base_path, _)| base_path).collect();
         write!(f, "CompositeService accepting base paths: {:?}", str_vec,)

--- a/src/composites.rs
+++ b/src/composites.rs
@@ -93,15 +93,6 @@ where
     V: NotFound<V> + 'static,
     W: 'static;
 
-// Workaround for https://github.com/rust-lang-nursery/rust-clippy/issues/2226
-#[cfg_attr(
-    feature = "cargo-clippy",
-    allow(
-        renamed_and_removed_lints,
-        new_without_default_derive,
-        clippy::new_without_default_derive
-    )
-)]
 impl<C, U, V: NotFound<V>, W> CompositeMakeService<C, U, V, W> {
     /// create an empty `CompositeMakeService`
     pub fn new() -> Self {

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -1,10 +1,4 @@
 //! Utility methods for instantiating common connectors for clients.
-extern crate hyper_tls;
-#[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "ios")))]
-extern crate native_tls;
-#[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "ios")))]
-extern crate openssl;
-
 use std::path::Path;
 
 use hyper;

--- a/src/context.rs
+++ b/src/context.rs
@@ -6,8 +6,8 @@
 //!
 //! See the `context_tests` module below for examples of how to use.
 
-use super::XSpanIdString;
-use auth::{AuthData, Authorization};
+use crate::XSpanIdString;
+use crate::auth::{AuthData, Authorization};
 use futures::future::Future;
 use hyper;
 use std::marker::Sized;
@@ -163,7 +163,7 @@ pub trait Push<T> {
     /// The type that results from adding an item.
     type Result;
     /// Inserts a value.
-    fn push(self, T) -> Self::Result;
+    fn push(self, value: T) -> Self::Result;
 }
 
 /// Defines a struct that can be used to build up contexts recursively by

--- a/src/context.rs
+++ b/src/context.rs
@@ -465,7 +465,7 @@ macro_rules! make_context {
 
 /// Context wrapper, to bind an API with a context.
 #[derive(Debug)]
-pub struct ContextWrapper<'a, T: 'a, C> {
+pub struct ContextWrapper<'a, T, C> {
     api: &'a T,
     context: C,
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -6,8 +6,8 @@
 //!
 //! See the `context_tests` module below for examples of how to use.
 
-use crate::XSpanIdString;
 use crate::auth::{AuthData, Authorization};
+use crate::XSpanIdString;
 use futures::future::Future;
 use hyper;
 use std::marker::Sized;
@@ -45,8 +45,6 @@ use std::marker::Sized;
 ///         Box::new(ok(hyper::Response::new(hyper::Body::empty())))
 ///     }
 /// }
-///
-/// # fn main() {}
 /// ```
 pub trait Has<T> {
     /// Get an immutable reference to the value.
@@ -104,8 +102,6 @@ pub trait Has<T> {
 ///         self.inner.call(req)
 ///     }
 /// }
-///
-/// # fn main() {}
 pub trait Pop<T> {
     /// The type that remains after the value has been popped.
     type Result;
@@ -157,8 +153,6 @@ pub trait Pop<T> {
 ///         self.inner.call(req)
 ///     }
 /// }
-///
-/// # fn main() {}
 pub trait Push<T> {
     /// The type that results from adding an item.
     type Result;
@@ -420,8 +414,6 @@ new_context_type!(
 /// fn do_nothing(input: ExampleContext1) -> ExampleContext2 {
 ///     input
 /// }
-///
-/// # fn main() {}
 /// ```
 #[macro_export]
 macro_rules! make_context_ty {

--- a/src/context.rs
+++ b/src/context.rs
@@ -426,7 +426,7 @@ new_context_type!(
 #[macro_export]
 macro_rules! make_context_ty {
     ($context_name:ident, $empty_context_name:ident, $type:ty $(, $types:ty)* $(,)* ) => {
-        $context_name<$type, make_context_ty!($context_name, $empty_context_name, $($types),*)>
+        $context_name<$type, $crate::make_context_ty!($context_name, $empty_context_name, $($types),*)>
     };
     ($context_name:ident, $empty_context_name:ident $(,)* ) => {
         $empty_context_name
@@ -464,7 +464,7 @@ macro_rules! make_context_ty {
 #[macro_export]
 macro_rules! make_context {
     ($context_name:ident, $empty_context_name:ident, $value:expr $(, $values:expr)* $(,)*) => {
-        make_context!($context_name, $empty_context_name, $($values),*).push($value)
+        $crate::make_context!($context_name, $empty_context_name, $($values),*).push($value)
     };
     ($context_name:ident, $empty_context_name:ident $(,)* ) => {
         $empty_context_name::default()

--- a/src/drop_context.rs
+++ b/src/drop_context.rs
@@ -1,7 +1,7 @@
 //! Hyper service that drops a context to an incoming request and passes it on
 //! to a wrapped service.
 
-use context::ContextualPayload;
+use crate::context::ContextualPayload;
 use futures::Future;
 use hyper;
 use hyper::{Error, Request};

--- a/src/header.rs
+++ b/src/header.rs
@@ -31,7 +31,7 @@ impl Default for XSpanIdString {
 }
 
 impl fmt::Display for XSpanIdString {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,24 +1,5 @@
 //! Support crate for Swagger codegen.
-#![warn(missing_docs, missing_debug_implementations)]
-#![deny(unused_extern_crates)]
-
-#[cfg(feature = "serdejson")]
-extern crate serde;
-#[cfg(feature = "serdejson")]
-extern crate serde_json;
-#[cfg(feature = "serdejson")]
-#[cfg(test)]
-#[macro_use]
-extern crate serde_derive;
-
-extern crate base64;
-extern crate chrono;
-extern crate futures;
-extern crate hyper;
-extern crate hyper_old_types;
-#[cfg(feature = "multipart")]
-extern crate mime;
-extern crate uuid;
+#![deny(missing_docs, missing_debug_implementations, unused_extern_crates)]
 
 use std::error;
 use std::fmt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ impl<T> ErrorBound for T where T: Into<Box<dyn std::error::Error + Send + Sync>>
 pub struct ApiError(pub String);
 
 impl fmt::Display for ApiError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let debug: &dyn fmt::Debug = self;
         debug.fmt(f)
     }

--- a/src/nullable_format.rs
+++ b/src/nullable_format.rs
@@ -1,6 +1,5 @@
 // These functions are only used if the API uses Nullable properties, so allow them to be
 // dead code.
-#![allow(dead_code)]
 #[cfg(feature = "serdejson")]
 use serde::de::Error as SerdeError;
 #[cfg(feature = "serdejson")]
@@ -640,6 +639,7 @@ where
 #[cfg(feature = "serdejson")]
 mod serde_tests {
     use super::*;
+    use serde::{Serialize, Deserialize};
 
     // Set up:
     #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/src/nullable_format.rs
+++ b/src/nullable_format.rs
@@ -639,7 +639,7 @@ where
 #[cfg(feature = "serdejson")]
 mod serde_tests {
     use super::*;
-    use serde::{Serialize, Deserialize};
+    use serde::{Deserialize, Serialize};
 
     // Set up:
     #[derive(Clone, Debug, Deserialize, Serialize)]


### PR DESCRIPTION
This updates swagger-rs to Rust 2018 edition.

This means we need Rust 1.31 to build - but given we don't have a policy other than "Builds on stable Rust", I don't think this constitutes an API break.