### PR TITLE
Use hyper-tls 0.3 instead

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,5 +35,5 @@ hyper-openssl = "0.7.1"
 openssl = "0.10.28"
 
 [target.'cfg(any(target_os = "macos", target_os = "windows", target_os = "ios"))'.dependencies]
-hyper-tls = "0.4.1"
+hyper-tls = "0.3"
 native-tls = "0.2"


### PR DESCRIPTION
hyper-tls 0.4 is compatible with Hyper 0.13, not Hyper 0.12