### PR TITLE
Ensure futures are Send and 'static

### DIFF
--- a/src/body.rs
+++ b/src/body.rs
@@ -1,31 +1,27 @@
 /// Helper methods to act on hyper::Body
-
-use std::pin::Pin;
-use std::future::Future;
 use futures::stream::{Stream, StreamExt};
 use hyper::body::Bytes;
 
 /// Additional function for hyper::Body
 pub trait BodyExt {
-
     /// Raw body type
     type Raw;
 
     /// Error if we can't gather up the raw body
     type Error;
 
-
     /// Collect the body into a raw form
-    fn to_raw(self) -> Pin<Box<dyn Future<Output=Result<Self::Raw, Self::Error>> + Send>>;
+    fn to_raw(self) -> futures::future::BoxFuture<'static, Result<Self::Raw, Self::Error>>;
 }
 
-impl<T, E> BodyExt for T where
-    T: Stream<Item=Result<Bytes, E>> + Unpin + Send + 'static
+impl<T, E> BodyExt for T
+where
+    T: Stream<Item = Result<Bytes, E>> + Unpin + Send + 'static,
 {
     type Raw = Vec<u8>;
     type Error = E;
 
-    fn to_raw(mut self) -> Pin<Box<dyn Future<Output=Result<Self::Raw, Self::Error>> + Send>> {
+    fn to_raw(mut self) -> futures::future::BoxFuture<'static, Result<Self::Raw, Self::Error>> {
         Box::pin(async {
             let mut raw = Vec::new();
             while let (Some(chunk), rest) = self.into_future().await {

--- a/src/context.rs
+++ b/src/context.rs
@@ -494,7 +494,6 @@ impl<T: Clone, C: Clone> Clone for ContextWrapper<T, C> {
     }
 }
 
-
 /// Trait designed to ensure consistency in context used by swagger middlewares
 ///
 /// ```rust


### PR DESCRIPTION
This is needed implicitly all over the place in hyper-land (and really in any async land where a future might not be pinned to a thread).

Also, takes advantage of `futures::future::BoxFuture` which is pretty much exactly what you had before only it's `+ Send` and has a space to write that it's `'static` explictly.