### PR TITLE
Add frunk support for swagger::Nullable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
     before_script:
     - rustup component add clippy-preview
     script:
-    - cargo clippy -- -D warnings --all-features
+    - cargo clippy --all-features -- -D warnings
   - rust: stable
     script:
     - cargo build --all-features

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,10 @@ matrix:
     before_script:
     - rustup component add clippy-preview
     script:
-    - cargo clippy -- -D warnings
+    - cargo clippy -- -D warnings --all-features
+  - rust: stable
+    script:
+    - cargo build --all-features
   - rust: stable
     env: RUSTFMT=1
     before_script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
+- Add frunk support for swagger::Nullable
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ repository = "Metaswitch/swagger-rs"
 [features]
 default = ["serdejson"]
 multipart = ["mime"]
+conversion = ["frunk", "frunk_core", "frunk-enum-core", "frunk-enum-derive"]
 serdejson = ["serde", "serde_json"]
 
 [dependencies]
@@ -33,3 +34,8 @@ uuid = {version = "0.7", features = ["serde", "v4"]}
 hyper-old-types = "0.11.0"
 chrono = "0.4.6"
 
+# Conversion
+frunk = { version = "0.3.0", optional = true }
+frunk_core = { version = "0.3.0", optional = true }
+frunk-enum-core = { version = "0.2.0", optional = true }
+frunk-enum-derive = { version = "0.2.0", optional = true }

--- a/src/add_context.rs
+++ b/src/add_context.rs
@@ -4,7 +4,6 @@
 use crate::context::ContextualPayload;
 use crate::{ErrorBound, Push, XSpanIdString};
 use futures::Future;
-use hyper;
 use hyper::Request;
 use std::marker::PhantomData;
 

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -3,7 +3,6 @@
 use crate::context::ContextualPayload;
 use crate::{ErrorBound, Push};
 use futures::future::Future;
-use hyper;
 use hyper::body::Payload;
 use hyper::header::AUTHORIZATION;
 use hyper::service::{MakeService, Service};

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -1,8 +1,6 @@
 //! Utility methods for instantiating common connectors for clients.
 use std::path::Path;
 
-use hyper;
-
 /// Returns a function which creates an http-connector. Used for instantiating
 /// clients with custom connectors
 pub fn http_connector() -> Box<dyn Fn() -> hyper::client::HttpConnector + Send + Sync> {

--- a/src/context.rs
+++ b/src/context.rs
@@ -9,7 +9,6 @@
 use crate::auth::{AuthData, Authorization};
 use crate::XSpanIdString;
 use futures::future::Future;
-use hyper;
 use std::marker::Sized;
 
 /// Defines methods for accessing, modifying, adding and removing the data stored

--- a/src/multipart.rs
+++ b/src/multipart.rs
@@ -1,7 +1,6 @@
 //! Helper functions for multipart support
 
 use hyper::header::{HeaderMap, CONTENT_TYPE};
-use mime;
 
 /// Utility function to get the multipart boundary marker (if any) from the Headers.
 pub fn boundary(headers: &HeaderMap) -> Option<String> {

--- a/src/nullable_format.rs
+++ b/src/nullable_format.rs
@@ -15,6 +15,7 @@ use std::mem;
 ///
 /// Nullable implements many of the same methods as the Option type (map, unwrap, etc).
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "conversion", derive(frunk_enum_derive::LabelledGenericEnum))]
 pub enum Nullable<T> {
     /// Null value
     Null,


### PR DESCRIPTION
Currently if a OpenAPI model includes a nullable field, we can't use frunk to transmogrify it into a identical structure using `swagger::Nullable`