### PR TITLE
Revert "Add frunk support for swagger::Nullable"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ repository = "Metaswitch/swagger-rs"
 [features]
 default = ["serdejson"]
 multipart = ["mime"]
-conversion = ["frunk", "frunk_core", "frunk-enum-core", "frunk-enum-derive"]
 serdejson = ["serde", "serde_json"]
 
 [dependencies]
@@ -30,12 +29,6 @@ futures = "0.1"
 uuid = {version = "0.7", features = ["serde", "v4"]}
 hyper-old-types = "0.11.0"
 chrono = "0.4.6"
-
-# Conversion
-frunk = { version = "0.3.0", optional = true }
-frunk_core = { version = "0.3.0", optional = true }
-frunk-enum-core = { version = "0.2.0", optional = true }
-frunk-enum-derive = { version = "0.2.0", optional = true }
 
 [target.'cfg(not(any(target_os = "macos", target_os = "windows", target_os = "ios")))'.dependencies]
 hyper-openssl = "0.7.1"

--- a/src/nullable_format.rs
+++ b/src/nullable_format.rs
@@ -15,7 +15,6 @@ use std::mem;
 ///
 /// Nullable implements many of the same methods as the Option type (map, unwrap, etc).
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-#[cfg_attr(feature = "conversion", derive(frunk_enum_derive::LabelledGenericEnum))]
 pub enum Nullable<T> {
     /// Null value
     Null,


### PR DESCRIPTION
This reverts https://github.com/Metaswitch/swagger-rs/pull/115 which caused problems due to https://github.com/lloydmeta/frunk/issues/143 by merging forward https://github.com/Metaswitch/swagger-rs/pull/116