### PR TITLE
Upgrade to Hyper 0.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ rust:
 - stable
 - beta
 - nightly
+os:
+- linux
+- osx
 before_script:
 - |
   ROOT_PACKAGE=swagger;

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,6 @@ rust:
 os:
 - linux
 - osx
-before_script:
-- |
-  ROOT_PACKAGE=swagger;
-  RUST_VERSION=$(cargo metadata --no-deps --format-version 1 | jq -er "[.packages[] | select(.name == \"$ROOT_PACKAGE\") | .version][0]");
-  (grep -q "## \[$RUST_VERSION\] -" CHANGELOG.md || (echo "Missing CHANGELOG entry for version $RUST_VERSION"; /bin/false)) &&
-  (grep -q "\[Unreleased\]: .*/$RUST_VERSION\.\.\.HEAD$" CHANGELOG.md || (echo "Unreleased tag in CHANGELOG footer not updated for version $RUST_VERSION"; /bin/false)) &&
-  (grep -q "\[$RUST_VERSION\]: .*\.\.\.$RUST_VERSION$" CHANGELOG.md || (echo "Missing tag for version $RUST_VERSION in CHANGELOG footer"; /bin/false)) &&
-  echo "CHANGELOG is up-to-date for version $RUST_VERSION."
 matrix:
   allow_failures:
   - rust: nightly
@@ -34,6 +26,17 @@ matrix:
     script:
     - rustup component list --installed
     - cargo fmt -- --check
+  - rust: stable
+    os: linux
+    env: CHECK_CHANGELOG=1
+    script:
+    - |
+      ROOT_PACKAGE=swagger;
+      RUST_VERSION=$(cargo metadata --no-deps --format-version 1 | jq -er "[.packages[] | select(.name == \"$ROOT_PACKAGE\") | .version][0]");
+      (grep -q "## \[$RUST_VERSION\] -" CHANGELOG.md || (echo "Missing CHANGELOG entry for version $RUST_VERSION"; /bin/false)) &&
+      (grep -q "\[Unreleased\]: .*/$RUST_VERSION\.\.\.HEAD$" CHANGELOG.md || (echo "Unreleased tag in CHANGELOG footer not updated for version $RUST_VERSION"; /bin/false)) &&
+      (grep -q "\[$RUST_VERSION\]: .*\.\.\.$RUST_VERSION$" CHANGELOG.md || (echo "Missing tag for version $RUST_VERSION in CHANGELOG footer"; /bin/false)) &&
+      echo "CHANGELOG is up-to-date for version $RUST_VERSION."
 branches:
   only:
   - staging

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Added
+### Breaking Changes
+- Support Hyper 0.14 and match features
+  - Add new feature `tcp` to signal HTTP support
+  - Add new feature `tls` to signal HTTP(S) support
+  - Add new feature `client` to signal Client support
+  - Add new feature `server` to signal Server support
 
-### Changed
+### Added
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixes
 - Upgrade base64 to 0.13
+- Upgrade bytes to 1.0
 
 ## [5.0.2] - 2021-01-13
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixes
 - Upgrade base64 to 0.13
 - Upgrade bytes to 1.0
+- Upgrade tokio to 1.0
 
 ## [5.0.2] - 2021-01-13
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-### Removed
+### Fixes
+- Upgrade base64 to 0.13
 
 ## [5.0.2] - 2021-01-13
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,8 @@ tcp = ["hyper/tcp"]
 tls = ["native-tls", "openssl", "hyper-openssl", "hyper-tls"]
 
 [dependencies]
-base64 = "0.12"
-serde = { version = "1.0.119", optional = true, features = ["derive"] }
+base64 = "0.13"
+serde = { version = "1.0", optional = true, features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
 hyper = "0.14"
 slog = { version = "2", features = [ "max_level_trace", "release_max_level_debug"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,14 +18,20 @@ default = ["serdejson"]
 multipart_form = ["mime"]
 multipart_related = ["mime_multipart", "hyper_0_10", "mime_0_2"]
 serdejson = ["serde", "serde_json"]
+server = ["hyper/server"]
+http1 = ["hyper/http1"]
+http2 = ["hyper/http2"]
+client = ["hyper/client"]
+tcp = ["hyper/tcp"]
+tls = ["native-tls", "openssl", "hyper-openssl", "hyper-tls"]
 
 [dependencies]
 base64 = "0.12"
 serde = { version = "1.0.119", optional = true, features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
-hyper = "0.13.1"
+hyper = "0.14"
 slog = { version = "2", features = [ "max_level_trace", "release_max_level_debug"] }
-uuid = {version = "0.8", features = ["serde", "v4"]}
+uuid = { version = "0.8", features = ["serde", "v4"] }
 hyper-old-types = "0.11.0"
 chrono = "0.4.6"
 futures = "0.3"
@@ -39,12 +45,12 @@ mime_multipart = {version = "0.5", optional = true}
 mime_0_2 = { package = "mime", version = "0.2.6", optional = true }
 
 [target.'cfg(not(any(target_os = "macos", target_os = "windows", target_os = "ios")))'.dependencies]
-hyper-openssl = "0.8.0"
-openssl = "0.10.28"
+hyper-openssl = { version = "0.9.0", optional = true }
+openssl = { version = "0.10.28", optional = true }
 
 [target.'cfg(any(target_os = "macos", target_os = "windows", target_os = "ios"))'.dependencies]
-hyper-tls = "0.4"
-native-tls = "0.2"
+hyper-tls = { version = "0.5", optional = true }
+native-tls = { version = "0.2", optional = true }
 
 [dev-dependencies]
 tokio = {version = "0.2", features = ["macros"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,3 +55,4 @@ native-tls = { version = "0.2", optional = true }
 [dev-dependencies]
 tokio = {version = "1.0", features = ["macros", "rt"]}
 bytes = "1.0"
+hyper = { version = "0.14", features = ["client", "http1", "tcp"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,5 +53,5 @@ hyper-tls = { version = "0.5", optional = true }
 native-tls = { version = "0.2", optional = true }
 
 [dev-dependencies]
-tokio = {version = "0.2", features = ["macros"]}
+tokio = {version = "1.0", features = ["macros", "rt"]}
 bytes = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ tls = ["native-tls", "openssl", "hyper-openssl", "hyper-tls"]
 
 [dependencies]
 base64 = "0.13"
-serde = { version = "1.0", optional = true, features = ["derive"] }
+serde = { version = "1.0.119", optional = true, features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
 hyper = "0.14"
 slog = { version = "2", features = [ "max_level_trace", "release_max_level_debug"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,4 +54,4 @@ native-tls = { version = "0.2", optional = true }
 
 [dev-dependencies]
 tokio = {version = "0.2", features = ["macros"]}
-bytes = "0.5"
+bytes = "1.0"

--- a/src/base64_format.rs
+++ b/src/base64_format.rs
@@ -1,5 +1,3 @@
-// These functions are only used if the API uses base64-encoded properties, so allow them to be
-// dead code.
 #[cfg(feature = "serdejson")]
 use base64::{decode, encode, DecodeError};
 #[cfg(feature = "serdejson")]

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -1,7 +1,13 @@
 //! Utility methods for instantiating common connectors for clients.
-#[cfg(all(any(target_os = "macos", target_os = "windows", target_os = "ios"), feature="tls"))]
+#[cfg(all(
+    any(target_os = "macos", target_os = "windows", target_os = "ios"),
+    feature = "tls"
+))]
 use std::convert::From as _;
-#[cfg(all(not(any(target_os = "macos", target_os = "windows", target_os = "ios")), feature="tls"))]
+#[cfg(all(
+    not(any(target_os = "macos", target_os = "windows", target_os = "ios")),
+    feature = "tls"
+))]
 use std::path::{Path, PathBuf};
 
 /// HTTP Connector construction
@@ -22,7 +28,7 @@ pub struct Builder {}
 
 impl Builder {
     /// Use HTTPS instead of HTTP
-    #[cfg(feature="tls")]
+    #[cfg(feature = "tls")]
     pub fn https(self) -> HttpsBuilder {
         HttpsBuilder {
             #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "ios")))]
@@ -33,14 +39,14 @@ impl Builder {
     }
 
     /// Build a HTTP connector
-    #[cfg(feature="tcp")]
+    #[cfg(feature = "tcp")]
     pub fn build(self) -> hyper::client::connect::HttpConnector {
         hyper::client::connect::HttpConnector::new()
     }
 }
 
 /// Builder for HTTPS connectors
-#[cfg(feature="tls")]
+#[cfg(feature = "tls")]
 #[derive(Debug)]
 pub struct HttpsBuilder {
     #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "ios")))]
@@ -49,7 +55,7 @@ pub struct HttpsBuilder {
     client_cert: Option<(PathBuf, PathBuf)>,
 }
 
-#[cfg(feature="tls")]
+#[cfg(feature = "tls")]
 impl HttpsBuilder {
     /// Pin the CA certificate for the server's certificate.
     ///

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -1,7 +1,7 @@
 //! Utility methods for instantiating common connectors for clients.
-#[cfg(any(target_os = "macos", target_os = "windows", target_os = "ios"))]
+#[cfg(all(any(target_os = "macos", target_os = "windows", target_os = "ios"), feature="tls"))]
 use std::convert::From as _;
-#[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "ios")))]
+#[cfg(all(not(any(target_os = "macos", target_os = "windows", target_os = "ios")), feature="tls"))]
 use std::path::{Path, PathBuf};
 
 /// HTTP Connector construction
@@ -22,6 +22,7 @@ pub struct Builder {}
 
 impl Builder {
     /// Use HTTPS instead of HTTP
+    #[cfg(feature="tls")]
     pub fn https(self) -> HttpsBuilder {
         HttpsBuilder {
             #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "ios")))]
@@ -32,12 +33,14 @@ impl Builder {
     }
 
     /// Build a HTTP connector
-    pub fn build(self) -> hyper::client::HttpConnector {
-        hyper::client::HttpConnector::new()
+    #[cfg(feature="tcp")]
+    pub fn build(self) -> hyper::client::connect::HttpConnector {
+        hyper::client::connect::HttpConnector::new()
     }
 }
 
 /// Builder for HTTPS connectors
+#[cfg(feature="tls")]
 #[derive(Debug)]
 pub struct HttpsBuilder {
     #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "ios")))]
@@ -46,6 +49,7 @@ pub struct HttpsBuilder {
     client_cert: Option<(PathBuf, PathBuf)>,
 }
 
+#[cfg(feature="tls")]
 impl HttpsBuilder {
     /// Pin the CA certificate for the server's certificate.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,10 +27,14 @@ pub mod context;
 pub use context::{ContextBuilder, ContextWrapper, EmptyContext, Has, Pop, Push};
 
 /// Module with utilities for creating connectors with hyper.
+#[cfg(feature="client")]
 pub mod connector;
+#[cfg(feature="client")]
 pub use connector::Connector;
 
+#[cfg(all(feature="server", any(feature="http1", feature="http2")))]
 pub mod composites;
+#[cfg(all(feature="server", any(feature="http1", feature="http2")))]
 pub use composites::{CompositeMakeService, CompositeService, NotFound};
 
 pub mod add_context;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,14 +27,14 @@ pub mod context;
 pub use context::{ContextBuilder, ContextWrapper, EmptyContext, Has, Pop, Push};
 
 /// Module with utilities for creating connectors with hyper.
-#[cfg(feature="client")]
+#[cfg(feature = "client")]
 pub mod connector;
-#[cfg(feature="client")]
+#[cfg(feature = "client")]
 pub use connector::Connector;
 
-#[cfg(all(feature="server", any(feature="http1", feature="http2")))]
+#[cfg(all(feature = "server", any(feature = "http1", feature = "http2")))]
 pub mod composites;
-#[cfg(all(feature="server", any(feature="http1", feature="http2")))]
+#[cfg(all(feature = "server", any(feature = "http1", feature = "http2")))]
 pub use composites::{CompositeMakeService, CompositeService, NotFound};
 
 pub mod add_context;


### PR DESCRIPTION
- Support Hyper 0.14 and match features
  - Add new feature `tcp` to signal HTTP support
  - Add new feature `tls` to signal HTTP(S) support
  - Add new feature `client` to signal Client support
  - Add new feature `server` to signal Server support
- Upgrade base64 to 0.13
- Upgrade tokio to 1.0