### PR TITLE
Workaround API break on private API in Serde 1.0.119

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
   - rust: nightly
   include:
   - rust: stable
-    env: CLIPPY=1
+    env: CHECK_CLIPPY=1
     before_script:
     - rustup component add clippy-preview
     script:
@@ -25,10 +25,11 @@ matrix:
     script:
     - cargo build --all-features
   - rust: stable
-    env: RUSTFMT=1
+    env: CHECK_RUSTFMT=1
     before_script:
     - rustup component add rustfmt
     script:
+    - rustup component list --installed
     - cargo fmt -- --check
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
   - rust: stable
     env: RUSTFMT=1
     before_script:
-    - rustup component add rustfmt-preview
+    - rustup component add rustfmt
     script:
     - cargo fmt -- --check
 branches:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-### Removed
+### Fixed
+- Fix interop with serde 1.0.119
 
 ## [5.0.0] - 2020-10-06
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ serdejson = ["serde", "serde_json"]
 
 [dependencies]
 base64 = "0.12"
-serde = { version = "1.0", optional = true, features = ["derive"] }
+serde = { version = "1.0.119", optional = true, features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
 hyper = "0.13.1"
 slog = { version = "2", features = [ "max_level_trace", "release_max_level_debug"] }

--- a/src/one_any_of.rs
+++ b/src/one_any_of.rs
@@ -1,8 +1,8 @@
 //! Implementations of OpenAPI `oneOf` and `anyOf` types, assuming rules are just types
 use serde::{
     de::Error,
-    __private::de::{Content, ContentRefDeserializer},
     Deserialize, Deserializer, Serialize, Serializer,
+    __private::de::{Content, ContentRefDeserializer},
 };
 use std::str::FromStr;
 use std::string::ToString;

--- a/src/one_any_of.rs
+++ b/src/one_any_of.rs
@@ -1,7 +1,7 @@
 //! Implementations of OpenAPI `oneOf` and `anyOf` types, assuming rules are just types
 use serde::{
     de::Error,
-    private::de::{Content, ContentRefDeserializer},
+    __private::de::{Content, ContentRefDeserializer},
     Deserialize, Deserializer, Serialize, Serializer,
 };
 use std::str::FromStr;

--- a/src/request_parser.rs
+++ b/src/request_parser.rs
@@ -47,6 +47,8 @@ pub trait RequestParser<B> {
     /// Retrieve the Swagger operation identifier that matches this request.
     ///
     /// Returns `Err(())` if this request does not match any known operation on this API.
+    // Allow this lint, as changing the signature is a breaking change.
+    #[allow(clippy::result_unit_err)]
     fn parse_operation_id(req: &Request<B>) -> Result<&'static str, ()>;
 }
 


### PR DESCRIPTION
We are using a private API in serde, and they've changed the API in a patch release to remind us this is wrong:

https://github.com/serde-rs/serde/commit/dd1f4b483ee204d58465064f6e5bf5a457543b54

That's annoying, but there's no easy viable alternative. This API is used by serde_derive on an untagged enum ( see https://github.com/serde-rs/serde/blob/b0c99ed761d638f2ca2f0437522e6c35ad254d93/serde_derive/src/de.rs#L1627-L1645 ), which is basically what we have.

We can't use serde_derive, because we want specific semantics. The only alternative is re-implementing the `ContentRefDeserializer` and `Content` objects, which is clearly worse than depending on this private API.

I've asked in Discord and raised https://github.com/serde-rs/serde/issues/1947 to query the serde devs.

Signed-off-by: Richard Whitehouse <richard.whitehouse@metaswitch.com>