### PR TITLE
Remove implicit conversions for ApiError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Breaking Changes
+- Remove implicit conversions for ApiError from `&str`, `String` and `serde_json::Error`
+- Update `mime_multipart` requirement from 0.5 to 0.6
+
 ### Added
 
-### Changed
-
-### Removed
 
 ## [6.0.0-alpha.1] - 2021-01-21
 ### Breaking Changes

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,22 +79,3 @@ impl error::Error for ApiError {
         "Failed to produce a valid response."
     }
 }
-
-impl<'a> From<&'a str> for ApiError {
-    fn from(e: &str) -> Self {
-        ApiError(e.to_string())
-    }
-}
-
-impl From<String> for ApiError {
-    fn from(e: String) -> Self {
-        ApiError(e)
-    }
-}
-
-#[cfg(feature = "serdejson")]
-impl From<serde_json::Error> for ApiError {
-    fn from(e: serde_json::Error) -> Self {
-        ApiError(format!("Response body did not match the schema: {}", e))
-    }
-}


### PR DESCRIPTION
While well intentioned, these make it too easy for server side business logic
to return ApiErrors without due care and attention.

As such, it's better for the calling code to explicitly provide the conversion
in cases where it's sensible.

Signed-off-by: Richard Whitehouse <richard.whitehouse@metaswitch.com>