### PR TITLE
Forward merge v5 fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ branches:
   - staging
   - trying
   - master
+  - v5
 deploy:
 - provider: script
   script: bash deploy.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Upgrade bytes to 1.0
 - Upgrade tokio to 1.0
 
+## [5.1.0] - 2021-03-04
+### Added
+- Support conversion for AnyOf and OneOf
+- Expose CompositeMakeServiceEntry
+
 ## [5.0.2] - 2021-01-13
 ### Fixed
 - Fix off by one error declaring OneOf and AnyOf with more than 10 arguments
@@ -175,6 +180,7 @@ No changes. We now think we've got enough to declare this crate stable.
 
 [Unreleased]: https://github.com/Metaswitch/swagger-rs/compare/6.0.0-alpha.1...HEAD
 [6.0.0-alpha.1]: https://github.com/Metaswitch/swagger-rs/compare/5.0.2...6.0.0-alpha.1
+[5.1.0]: https://github.com/Metaswitch/swagger-rs/compare/5.0.2...5.1.0
 [5.0.2]: https://github.com/Metaswitch/swagger-rs/compare/5.0.1...5.0.2
 [5.0.1]: https://github.com/Metaswitch/swagger-rs/compare/5.0.0...5.0.1
 [5.0.0]: https://github.com/Metaswitch/swagger-rs/compare/4.0.2...5.0.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ http2 = ["hyper/http2"]
 client = ["hyper/client"]
 tcp = ["hyper/tcp"]
 tls = ["native-tls", "openssl", "hyper-openssl", "hyper-tls"]
+conversion = ["frunk", "frunk_derives", "frunk_core", "frunk-enum-core", "frunk-enum-derive"]
 
 [dependencies]
 base64 = "0.13"
@@ -35,6 +36,13 @@ uuid = { version = "0.8", features = ["serde", "v4"] }
 hyper-old-types = "0.11.0"
 chrono = "0.4.6"
 futures = "0.3"
+
+# Conversion
+frunk = { version = "0.3.0", optional = true }
+frunk_derives = { version = "0.3.0", optional = true }
+frunk_core = { version = "0.3.0", optional = true }
+frunk-enum-derive = { version = "0.2.1", optional = true }
+frunk-enum-core = { version = "0.2.1", optional = true }
 
 # multipart/form-data
 mime = { version = "0.3", optional = true }

--- a/src/composites.rs
+++ b/src/composites.rs
@@ -100,10 +100,17 @@ type CompositeServiceVec<ReqBody, ResBody, Error> = Vec<(
     Box<dyn CompositedService<ReqBody, ResBody, Error> + Send>,
 )>;
 
-type CompositeMakeServiceVec<Target, ReqBody, ResBody, Error, MakeError> = Vec<(
+type CompositeMakeServiceVec<Target, ReqBody, ResBody, Error, MakeError> =
+    Vec<CompositeMakeServiceEntry<Target, ReqBody, ResBody, Error, MakeError>>;
+
+/// Service which can be composited with other services as part of a CompositeMakeService
+///
+/// Consists of a base path for requests which should be handled by this service, and a boxed
+/// MakeService.
+pub type CompositeMakeServiceEntry<Target, ReqBody, ResBody, Error, MakeError> = (
     &'static str,
     Box<dyn CompositedMakeService<Target, ReqBody, ResBody, Error, MakeError> + Send>,
-)>;
+);
 
 /// Wraps a vector of pairs, each consisting of a base path as a `&'static str`
 /// and a `MakeService` instance. Implements `Deref<Vec>` and `DerefMut<Vec>` so

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ pub use connector::Connector;
 #[cfg(all(feature = "server", any(feature = "http1", feature = "http2")))]
 pub mod composites;
 #[cfg(all(feature = "server", any(feature = "http1", feature = "http2")))]
-pub use composites::{CompositeMakeService, CompositeService, NotFound};
+pub use composites::{CompositeMakeService, CompositeMakeServiceEntry, CompositeService, NotFound};
 
 pub mod add_context;
 pub use add_context::{AddContextMakeService, AddContextService};

--- a/src/one_any_of.rs
+++ b/src/one_any_of.rs
@@ -1,4 +1,6 @@
 //! Implementations of OpenAPI `oneOf` and `anyOf` types, assuming rules are just types
+#[cfg(feature = "conversion")]
+use frunk_enum_derive::LabelledGenericEnum;
 use serde::{
     de::Error,
     Deserialize, Deserializer, Serialize, Serializer,
@@ -15,6 +17,7 @@ macro_rules! common_one_any_of {
         $($i:ident),*
     ) => {
         /// $t
+        #[cfg_attr(feature = "conversion", derive(LabelledGenericEnum))]
         #[derive(Debug, PartialEq, Clone)]
         pub enum $t<$($i),*> where
             $($i: PartialEq,)*

--- a/src/request_parser.rs
+++ b/src/request_parser.rs
@@ -47,7 +47,7 @@ pub trait RequestParser<B> {
     /// Retrieve the Swagger operation identifier that matches this request.
     ///
     /// Returns `None` if this request does not match any known operation on this API.
-    fn parse_operation_id(req: &Request<B>) -> Result<&'static str, Box<dyn std::error::Error>>;
+    fn parse_operation_id(req: &Request<B>) -> Option<&'static str>;
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This merges forward a couple of features merged into v5 - primarily
- https://github.com/Metaswitch/swagger-rs/pull/139 - Support conversion for AnyOf and OneOf
- https://github.com/Metaswitch/swagger-rs/pull/140 - Expose CompositeMakeServiceEntry

It also fixes a clippy lint we were living with in v5.