### PR TITLE
Support Unix Domain Sockets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ http2 = ["hyper/http2"]
 client = ["hyper/client"]
 tcp = ["hyper/tcp"]
 tls = ["native-tls", "openssl", "hyper-openssl", "hyper-tls"]
+uds = ["tokio", "tokio/net"]
 conversion = ["frunk", "frunk_derives", "frunk_core", "frunk-enum-core", "frunk-enum-derive"]
 
 [dependencies]
@@ -51,6 +52,9 @@ mime = { version = "0.3", optional = true }
 hyper_0_10 = {package = "hyper", version = "0.10", default-features = false, optional=true}
 mime_multipart = {version = "0.6", optional = true}
 mime_0_2 = { package = "mime", version = "0.2.6", optional = true }
+
+# UDS (Unix Domain Sockets)
+tokio = { version = "1.0", default-features = false, optional = true }
 
 [target.'cfg(not(any(target_os = "macos", target_os = "windows", target_os = "ios")))'.dependencies]
 hyper-openssl = { version = "0.9.0", optional = true }

--- a/src/composites.rs
+++ b/src/composites.rs
@@ -267,7 +267,7 @@ where
         Poll::Ready(Ok(()))
     }
 
-    fn call(&mut self, target: &'a tokio::net::UnixStream) -> Self::Future {
+    fn call(&mut self, _target: &'a tokio::net::UnixStream) -> Self::Future {
         let mut services = Vec::with_capacity(self.0.len());
         for (path, service) in &mut self.0 {
             let path: &'static str = path;


### PR DESCRIPTION
Andy,

This adds support to CompositeMakeService to support Unix domain sockets.

Tested against a microservice internally.

Signed-off-by: Richard Whitehouse <richard.whitehouse@metaswitch.com>