### PR TITLE
Remove Chrono

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Added
-
 ### Changed
 
-### Removed
+### Added
+
+### Fixed
+- Remove private, unused dependency on `chrono`
 
 ## [6.1.0] - 2021-06-17
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ hyper = "0.14"
 slog = { version = "2", features = [ "max_level_trace", "release_max_level_debug"] }
 uuid = { version = "0.8", features = ["serde", "v4"] }
 hyper-old-types = "0.11.0"
-chrono = "0.4.6"
 futures = "0.3"
 
 # Conversion

--- a/release-changelog.sh
+++ b/release-changelog.sh
@@ -8,7 +8,7 @@ date=$(date +%Y-%m-%d)
 
 sed -i "s/^version = \".\+\"$/version = \"$version\"/" Cargo.toml
 
-sed -i "s/## \[Unreleased\]/## [Unreleased]\n### Added\n\n### Changed\n\n### Removed\n\n## [$version] - $date/" CHANGELOG.md
+sed -i "s/## \[Unreleased\]/## [Unreleased]\n### Changed\n\n### Added\n\n### Fixed\n\n## [$version] - $date/" CHANGELOG.md
 
 sed -i "s#\[Unreleased\]: https://github.com/Metaswitch/swagger-rs/compare/\(.*\)...HEAD#[Unreleased]: https://github.com/Metaswitch/swagger-rs/compare/$version...HEAD\n[$version]: https://github.com/Metaswitch/swagger-rs/compare/\1...$version#" CHANGELOG.md
 


### PR DESCRIPTION
Remove Chrono, as it's not used, and it's vulnerable to security vulnerabilities - particularly RUSTSEC-2020-0159 and RUSTSEC-2020-0071