### PR TITLE
Disable unused features of chrono crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
+- Disable unused features on chrono crate
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ hyper = "0.14"
 slog = { version = "2", features = [ "max_level_trace", "release_max_level_debug"] }
 uuid = { version = "0.8", features = ["serde", "v4"] }
 hyper-old-types = "0.11.0"
-chrono = "0.4.6"
+chrono = { version = "0.4.6", default-features = false }
 futures = "0.3"
 
 # Conversion


### PR DESCRIPTION
Specifically, this disables "oldtime" feature, which pulls in "time"
crate for backwards-compatibility reasons. We don't use it, and it will
eventually be removed from chrono, so let's avoid depending on it by
mistake.

This does not remove the time crate from the dependency tree just yet,
as time crate is still used by hyper-old-types crate, but it prevents
Component Governance Alerts from misidentifying the dependency (thus
limiting the number of alerts).

Signed-off-by: Patryk Obara <dreamer.tan@gmail.com>