### PR TITLE
Use new headers crate instead of hyper-old-types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
 ### Changed
+
+- *BREAKING* - Remove dependency and re-export of `hyper-old-types` which is no longer maintained.
+  - This changes the inner types of the `AuthData` enum and thus the various methods on it.
+      - The `hyper_old_types` are no longer re-exported, and the enums just wrap `String`s.
+  - The `auth::make_headers` function now returns an `Option<Credentials>` from the `headers` crate.
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,8 @@ serde_json = { version = "1.0", optional = true }
 hyper = "0.14"
 slog = { version = "2", features = [ "max_level_trace", "release_max_level_debug"] }
 uuid = { version = "0.8", features = ["serde", "v4"] }
-hyper-old-types = "0.11.0"
 futures = "0.3"
+headers = "0.3"
 
 # Conversion
 frunk = { version = "0.3.0", optional = true }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -3,7 +3,7 @@
 use crate::context::Push;
 use futures::future::FutureExt;
 pub use headers::authorization::{Basic, Bearer, Credentials};
-pub use headers::Authorization as Header;
+use headers::Authorization as Header;
 use hyper::header::AUTHORIZATION;
 use hyper::service::Service;
 use hyper::{HeaderMap, Request};

--- a/src/header.rs
+++ b/src/header.rs
@@ -15,8 +15,7 @@ impl XSpanIdString {
         let x_span_id = req.headers().get(X_SPAN_ID);
 
         x_span_id
-            .map(|x| x.to_str().ok())
-            .flatten()
+            .and_then(|x| x.to_str().ok())
             .map(|x| XSpanIdString(x.to_string()))
             .unwrap_or_default()
     }


### PR DESCRIPTION
Signed-off-by: Mark Thebridge <mark.thebridge@metaswitch.com>

`hyper-old-types` is bo lionger maintained.  Switch to the `headers` hyper crate instead - https://docs.rs/headers/latest/headers/authorization/index.html 

This is a breaking change because `swagger-rs` re-exported types.

* Rather than continue to re-export, I've made the `AuthData` enum variants just wrap Strings.  This is slightly uglier, but the inner `Basic` and `Bearer` types in `headers` can't be directly constructed, only decoded from an Authorization header, and this felt like a more efficient implementation.
* The `from_headers` method now returns an object implementing [`Credentials`](https://docs.rs/headers/latest/headers/authorization/trait.Credentials.html).

There were no existing tests of `AuthData` - not sure what would be useful to add, but will do if there's anything you think would help?