### PR TITLE
Fix clippy warnings in Rust 1.70

### DIFF
--- a/src/base64_format.rs
+++ b/src/base64_format.rs
@@ -33,7 +33,7 @@ impl<'de> Deserialize<'de> for ByteArray {
         D: Deserializer<'de>,
     {
         let s = String::deserialize(deserializer)?;
-        match decode(&s) {
+        match decode(s) {
             Ok(bin) => Ok(ByteArray(bin)),
             _ => Err(D::Error::custom("invalid base64")),
         }

--- a/src/header.rs
+++ b/src/header.rs
@@ -15,8 +15,7 @@ impl XSpanIdString {
         let x_span_id = req.headers().get(X_SPAN_ID);
 
         x_span_id
-            .map(|x| x.to_str().ok())
-            .flatten()
+            .and_then(|x| x.to_str().ok())
             .map(|x| XSpanIdString(x.to_string()))
             .unwrap_or_default()
     }

--- a/src/multipart/form.rs
+++ b/src/multipart/form.rs
@@ -6,7 +6,7 @@ use hyper::header::{HeaderMap, CONTENT_TYPE};
 pub fn boundary(headers: &HeaderMap) -> Option<String> {
     headers.get(CONTENT_TYPE).and_then(|content_type| {
         match content_type.to_str() {
-            Ok(ref val) => val.parse::<mime::Mime>().ok(),
+            Ok(val) => val.parse::<mime::Mime>().ok(),
             _ => None,
         }
         .and_then(|ref mime| {


### PR DESCRIPTION
This fixes all clippy warnings in Rust 1.70