### PR TITLE
Support serde_valid 0.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 ### Added
+- Support `serde_valid` 0.16.
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ conversion = ["frunk", "frunk_derives", "frunk_core", "frunk-enum-core", "frunk-
 base64 = "0.13"
 serde = { version = "1.0.119", optional = true, features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
-serde_valid = { version = "0.15", optional = true }
+serde_valid = { version = ">= 0.15, < 0.17", optional = true }
 regex = { version = "1", optional = true }
 paste = { version = "1", optional = true }
 hyper = "0.14"


### PR DESCRIPTION
This applies https://github.com/Metaswitch/swagger-rs/pull/170 without taking a breaking change.

We are vulnerable to the concerns discussed in https://github.com/rust-lang/cargo/issues/10599 - but on balance, this is a better trade-off, and downstream users can force the "right" resolution.