### PR TITLE
Fix doc build breakage on stable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,3 +75,4 @@ hyper = { version = "0.14", features = ["client", "http1", "tcp"] }
 [package.metadata.docs.rs]
 # Enable all features, pending https://github.com/rust-lang/rust/issues/43781 being resolved.
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@
 )]
 // Enable doc_auto_cfg, but only on doc builds
 // See https://github.com/rust-lang/rust/issues/43781 for details
-#![cfg_attr(doc, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg, doc_cfg))]
 
 use std::error;
 use std::fmt;


### PR DESCRIPTION
Fix:

```
 Documenting swagger v6.4.0
error[E0554]: `#![feature]` may not be used on the stable release channel
  --> swagger-6.4.0/src/lib.rs:40:18
   |
40 | #![cfg_attr(doc, feature(doc_auto_cfg))]
   |                  ^^^^^^^^^^^^^^^^^^^^^

For more information about this error, try `rustc --explain E0554`.
error: could not document `swagger`
```

We match the fix done in tower:
- src/lib.rs - https://github.com/tower-rs/tower/blob/bf4ea948346c59a5be03563425a7d9f04aadedf2/tower/src/lib.rs#L10C1-L10C53
- Cargo.toml - https://github.com/tower-rs/tower/blob/bf4ea948346c59a5be03563425a7d9f04aadedf2/tower/Cargo.toml#L98-L100