### PR TITLE
Feature/174/implement clone for make allow all authenticator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 ### Added
+- Implement `Clone` on `MakeAllowAllAuthenticator`.
 
 ### Fixed
 

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -96,6 +96,21 @@ where
     marker: PhantomData<RC>,
 }
 
+impl<T, RC> Clone for MakeAllowAllAuthenticator<T, RC>
+where
+    T: Clone,
+    RC: RcBound,
+    RC::Result: Send + 'static,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            subject: self.subject.clone(),
+            marker: PhantomData,
+        }
+    }
+}
+
 impl<T, RC> MakeAllowAllAuthenticator<T, RC>
 where
     RC: RcBound,


### PR DESCRIPTION
* Part of #174.

Heya, I was trying to get the OpenAPI `rust-server` generator to use `hyper 1.6`, and one of the parts needed for that to work is to pass in a `hyper::service::Service` to an async closure, which requires the closure to be `'static`.

Because the passed in `service` cannot be borrowed (which would make it not `'static`), either it would have to be constructed on each call, or `clone()`d. For cloning to work, `MakeAllowAllAuthenticator` needs to impl `Clone`, which I've done here.
