### PR TITLE
Fix request_parser so that macro_use is not required.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 ### Fixed
+- Fix request_parser so that macro_use is not required.
+  - Add "external" tests to ensure backward compatibility.
 
 ## [7.0.0] - 2025-11-12
 ### Changed

--- a/src/request_parser.rs
+++ b/src/request_parser.rs
@@ -13,11 +13,11 @@ macro_rules! request_parser_joiner {
     ($name:ident ,$($T:ty), *) => {
         struct $name;
 
-        impl <B> RequestParser<B> for $name
-            where $($T: RequestParser<B>, )*
+        impl <B> $crate::RequestParser<B> for $name
+            where $($T: $crate::RequestParser<B>, )*
         {
             fn parse_operation_id(request: &Request<B>) -> Option<&'static str> {
-                __impl_request_parser_joiner!(request, $($T), *)
+                $crate::__impl_request_parser_joiner!(request, $($T), *)
             }
         }
     };
@@ -27,11 +27,11 @@ macro_rules! request_parser_joiner {
 #[macro_export]
 #[doc(hidden)]
 macro_rules! __impl_request_parser_joiner {
-    ($argname:expr, $head:ty) => {<$head as RequestParser<B>>::parse_operation_id(&$argname)};
+    ($argname:expr, $head:ty) => {<$head as $crate::RequestParser<B>>::parse_operation_id(&$argname)};
     ($argname:expr, $head:ty, $( $tail:ty), *) => {
-        match <$head as RequestParser<B>>::parse_operation_id(&$argname) {
+        match <$head as $crate::RequestParser<B>>::parse_operation_id(&$argname) {
                 Some(s) => Some(s),
-                None => __impl_request_parser_joiner!($argname, $( $tail), *),
+                None => $crate::__impl_request_parser_joiner!($argname, $( $tail), *),
         }
     };
 }

--- a/tests/context_macros_external.rs
+++ b/tests/context_macros_external.rs
@@ -1,0 +1,34 @@
+use swagger::{make_context, make_context_ty, new_context_type, Has, Pop, Push};
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct Item1(u32);
+#[derive(Debug, Default, PartialEq, Eq)]
+struct Item2;
+#[derive(Debug, Default, PartialEq, Eq)]
+struct Item3;
+
+new_context_type!(ExtContext, ExtEmptyContext, Item1, Item2, Item3);
+
+#[test]
+fn context_macros_work_from_external_crate() {
+    let ctx = ExtEmptyContext.push(Item3).push(Item2).push(Item1(42));
+
+    let v: &Item1 = ctx.get();
+    assert_eq!(v.0, 42);
+
+    let (item2, ctx): (Item2, _) = ctx.pop();
+    let (_item3, _ctx): (Item3, _) = ctx.pop();
+
+    let _ = item2;
+}
+
+#[test]
+fn make_context_macros_work_from_external_crate() {
+    type Ctx = make_context_ty!(ExtContext, ExtEmptyContext, Item1, Item2, Item3);
+
+    let ctx1: Ctx = make_context!(ExtContext, ExtEmptyContext, Item1(5), Item2, Item3);
+    let ctx2: Ctx = ExtEmptyContext.push(Item3).push(Item2).push(Item1(5));
+
+    assert_eq!(Has::<Item1>::get(&ctx1).0, 5);
+    assert_eq!(ctx1, ctx2);
+}

--- a/tests/request_parser_joiner_macro.rs
+++ b/tests/request_parser_joiner_macro.rs
@@ -1,0 +1,45 @@
+use http::Request;
+use swagger::{request_parser_joiner, RequestParser};
+
+struct TestParser1;
+
+impl RequestParser<()> for TestParser1 {
+    fn parse_operation_id(request: &Request<()>) -> Option<&'static str> {
+        match request.uri().path() {
+            "/test/t11" => Some("t11"),
+            "/test/t12" => Some("t12"),
+            _ => None,
+        }
+    }
+}
+
+struct TestParser2;
+
+impl RequestParser<()> for TestParser2 {
+    fn parse_operation_id(request: &Request<()>) -> Option<&'static str> {
+        match request.uri().path() {
+            "/test/t21" => Some("t21"),
+            "/test/t22" => Some("t22"),
+            _ => None,
+        }
+    }
+}
+
+request_parser_joiner!(JoinedReqParser, TestParser1, TestParser2);
+
+#[test]
+fn request_parser_joiner_works_from_external_crate() {
+    let req1: Request<()> = Request::get("https://www.rust-lang.org/test/t11")
+        .body(())
+        .unwrap();
+    let req2: Request<()> = Request::get("https://www.rust-lang.org/test/t22")
+        .body(())
+        .unwrap();
+    let req3: Request<()> = Request::get("https://www.rust-lang.org/test/t33")
+        .body(())
+        .unwrap();
+
+    assert_eq!(JoinedReqParser::parse_operation_id(&req1), Some("t11"));
+    assert_eq!(JoinedReqParser::parse_operation_id(&req2), Some("t22"));
+    assert_eq!(JoinedReqParser::parse_operation_id(&req3), None);
+}


### PR DESCRIPTION
Add "external" tests to ensure backward compatibility.